### PR TITLE
Remove warnings from early stage of creation.

### DIFF
--- a/Juriba.Platform/Juriba.Platform.psd1
+++ b/Juriba.Platform/Juriba.Platform.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.Platform.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.0.36.0'
+    ModuleVersion     = '0.0.37.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -30,8 +30,7 @@
     Copyright         = '(c) Juriba. All rights reserved.'
 
     # Description of the functionality provided by this module
-    # Description       = 'PowerShell Module to interact with Juriba Platform.'
-    Description       = 'This module is currently under active development and is not intended for public use.'
+    Description       = 'PowerShell Module to interact with Juriba Platform.'
 
     # Minimum version of the PowerShell engine required by this module
     # PowerShellVersion = ''

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Juriba Platform PowerShell Module
 
-> **Warning** - This module is under active development
-
-## About
-
 A PowerShell module which can be used to interact with the Juriba Platform API.
 
 ## Installation


### PR DESCRIPTION
When the module was created last year we had warnings in place to make it clear that the module was experimental. We have had sufficient exposure and experience with this module to now remove these warnings.