### PR TITLE
Add description to ServiceNow manifest

### DIFF
--- a/Juriba.DPC.ServiceNow/Juriba.DPC.ServiceNow.psd1
+++ b/Juriba.DPC.ServiceNow/Juriba.DPC.ServiceNow.psd1
@@ -30,7 +30,7 @@ CompanyName = 'Juriba'
 Copyright = '(c) Juriba. All rights reserved.'
 
 # Description of the functionality provided by this module
-# Description = ''
+Description       = 'PowerShell Module to integrate Juriba DPC with ServiceNow.'
 
 # Minimum version of the PowerShell engine required by this module
 # PowerShellVersion = ''


### PR DESCRIPTION
Add missing description to ServiceNow manifest to allow for the module to be published to the PowerShell gallery.
