### PR TITLE
Updates to resolve PSScriptAnalyser warnings

### DIFF
--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.7.0'
+    ModuleVersion     = '1.1.8.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Juriba.DPC/Public/Get-JuribaEventLog.ps1
+++ b/Juriba.DPC/Public/Get-JuribaEventLog.ps1
@@ -1,4 +1,6 @@
-function Get-JuribaEventLogs {
+function Get-JuribaEventLog {
+    [Alias("Get-JuribaEventLogs")]
+    [OutputType([System.Object[]])]
     <#
         .SYNOPSIS
         Retrieves event logs for a specific service run.

--- a/Juriba.DPC/Public/Get-JuribaEventLogRun.ps1
+++ b/Juriba.DPC/Public/Get-JuribaEventLogRun.ps1
@@ -1,4 +1,5 @@
-function Get-JuribaEventLogRuns {
+function Get-JuribaEventLogRun {
+    [Alias("Get-JuribaEventLogRuns")]
     <#
         .SYNOPSIS
         Retrieves recent runs for a specified service from the Juriba API.

--- a/Juriba.DPC/Public/Get-JuribaEventLogService.ps1
+++ b/Juriba.DPC/Public/Get-JuribaEventLogService.ps1
@@ -1,5 +1,6 @@
 #requires -Version 7
-function Get-JuribaEventLogServices {
+function Get-JuribaEventLogService {
+    [Alias("Get-JuribaEventLogServices")]
     <#
         .SYNOPSIS
         Retrieves service information from the Juriba API.


### PR DESCRIPTION
- Renamed Get-JuribaEventLogs, Get-JuribaEventLogRuns, and Get-JuribaEventLogServices to their singular forms to comply with PSUseSingularNouns. Added aliases to preserve backward compatibility.
- Added output type to Get-JuribaEventLog.ps1 to comply with PSUseOutputTypeCorrectly.
- Updated module version to 1.1.8.0.
