### PR TITLE
Extend bulk and bulk async support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 *.csv
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ function Verb-JuribaEntity {
         Longer description including which API version is used.
 
         .PARAMETER Instance
-        Optional. Dashworks instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dashworks.app:8443
+        Optional. Juriba instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dpc.juriba.app
 
         .PARAMETER APIKey
         Optional. API key to be provided if not authenticating using Connect-Juriba.
@@ -64,7 +64,7 @@ function Verb-JuribaEntity {
         Description of what is returned.
 
         .EXAMPLE
-        PS> Verb-JuribaEntity @DwParams -ExampleParam "value"
+        PS> Verb-JuribaEntity -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxx" -ExampleParam "value"
     #>
     [CmdletBinding(SupportsShouldProcess)]  # Include SupportsShouldProcess for New/Set/Remove functions
     param(

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@ Examples/            - Example scripts organized by integration type
 
 ## CI/CD
 
-- **PR checks**: PSScriptAnalyzer runs on PRs touching `Juriba.DPC/**`. Excluded rule: `PSAvoidTrailingWhitespace`. All other rules must pass.
+- **PR checks**: PSScriptAnalyzer runs on PRs touching `Juriba.DPC/**` with `-EnableExit`. This means **all** findings fail the build, including Information-level (not just warnings/errors). Excluded rule: `PSAvoidTrailingWhitespace`.
 - **Publishing**: On push to `main` with changes in `Juriba.DPC/**`, the module is published to the PowerShell Gallery via `Publish-Module`.
-- Run PSScriptAnalyzer locally before committing: `Invoke-ScriptAnalyzer -Path .\Juriba.DPC -Recurse -ExcludeRule PSAvoidTrailingWhitespace`
+- Run PSScriptAnalyzer locally before committing: `Invoke-ScriptAnalyzer -Path .\Juriba.DPC -Recurse -EnableExit -ExcludeRule PSAvoidTrailingWhitespace`
+- Common pitfall: if a function returns different types depending on code path (e.g., a string in one branch, a PSObject in another), add `[OutputType([String])]` or the appropriate types to avoid `PSUseOutputTypeCorrectly` findings.
 
 ## Adding a New Function
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,153 @@
+# CLAUDE.md - Juriba.DPC PowerShell Module
+
+## Project Overview
+
+PowerShell module (`Juriba.DPC`) for interacting with the Juriba DPC API. Published to the PowerShell Gallery automatically on merge to `main`. There is also a `Juriba.DPC.ServiceNow` module which is not yet published and should be ignored unless explicitly asked about.
+
+## Project Structure
+
+```
+Juriba.DPC/
+  Public/          - Exported functions (one function per file)
+  Private/         - Internal helper functions (not exported)
+  Juriba.DPC.psm1  - Root module (dot-sources Public/ and Private/, exports Public)
+  Juriba.DPC.psd1  - Module manifest (version, exports list, metadata)
+Examples/            - Example scripts organized by integration type
+.github/workflows/
+  checks.yaml      - PR validation: PSScriptAnalyzer
+  publish.yaml     - Auto-publish to PowerShell Gallery on merge to main
+```
+
+## CI/CD
+
+- **PR checks**: PSScriptAnalyzer runs on PRs touching `Juriba.DPC/**`. Excluded rule: `PSAvoidTrailingWhitespace`. All other rules must pass.
+- **Publishing**: On push to `main` with changes in `Juriba.DPC/**`, the module is published to the PowerShell Gallery via `Publish-Module`.
+- Run PSScriptAnalyzer locally before committing: `Invoke-ScriptAnalyzer -Path .\Juriba.DPC -Recurse -ExcludeRule PSAvoidTrailingWhitespace`
+
+## Adding a New Function
+
+1. Create a `.ps1` file in `Juriba.DPC\Public\` named exactly after the function.
+2. Add the function name to the `FunctionsToExport` array in `Juriba.DPC.psd1` (alphabetical within its verb group).
+3. Increment `ModuleVersion` in `Juriba.DPC.psd1`.
+
+## Function Naming
+
+- Pattern: `[Verb]-Juriba[Entity]` (e.g., `Get-JuribaTeam`, `New-JuribaImportDevice`)
+- Use approved PowerShell verbs: `Get`, `New`, `Set`, `Remove`, `Add`, `Connect`, `Disconnect`, `Invoke`, `Export`, `Start`, `Stop`, `Update`
+- Existing functions have a legacy `Dw` alias from when the module was named `Juriba.Dashworks` (e.g., `[alias("Get-DwTeam")]`). New functions do not need an alias.
+
+## Function Template
+
+Follow this structure for all new functions:
+
+```powershell
+#requires -Version 7
+function Verb-JuribaEntity {
+    <#
+        .SYNOPSIS
+        Short one-line description.
+
+        .DESCRIPTION
+        Longer description including which API version is used.
+
+        .PARAMETER Instance
+        Optional. Dashworks instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dashworks.app:8443
+
+        .PARAMETER APIKey
+        Optional. API key to be provided if not authenticating using Connect-Juriba.
+
+        .PARAMETER ExampleParam
+        Description of the parameter.
+
+        .OUTPUTS
+        Description of what is returned.
+
+        .EXAMPLE
+        PS> Verb-JuribaEntity @DwParams -ExampleParam "value"
+    #>
+    [CmdletBinding(SupportsShouldProcess)]  # Include SupportsShouldProcess for New/Set/Remove functions
+    param(
+        [Parameter(Mandatory=$false)]
+        [string]$Instance,
+        [Parameter(Mandatory=$false)]
+        [string]$APIKey,
+        [Parameter(Mandatory=$true)]
+        [string]$ExampleParam
+    )
+
+    if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
+        $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
+        $Instance = $dwConnection.instance
+    }
+
+    if ($APIKey -and $Instance) {
+        $uri = "{0}/apiv2/endpoint" -f $Instance
+        $headers = @{'x-api-key' = $APIKey}
+
+        try {
+            if ($PSCmdlet.ShouldProcess($ExampleParam)) {
+                $result = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+                return $result
+            }
+        }
+        catch {
+            Write-Error $_
+        }
+    } else {
+        Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
+    }
+}
+```
+
+## Key Patterns
+
+### Authentication
+- `$Instance` and `$APIKey` are always optional parameters (listed first).
+- Functions must check for the global `$dwConnection` object set by `Connect-Juriba` as a fallback.
+- The connection check block is identical across all functions (see template above).
+
+### API Calls
+- Construct URIs with string formatting: `"{0}/apiv2/endpoint/{1}" -f $Instance, $Id`
+- Headers: `@{'x-api-key' = $APIKey}`
+- Use `Invoke-RestMethod` for newer functions (apiv2). Older functions may use `Invoke-WebRequest` with manual `ConvertFrom-Json`.
+- JSON body: build a hashtable, pipe to `ConvertTo-Json`, encode with `[System.Text.Encoding]::UTF8.GetBytes()` for POST/PUT/PATCH.
+- Content type: `"application/json"`
+- URL-encode filter parameters: `[System.Web.HttpUtility]::UrlEncode("eq(name,'{0}')" -f $Name)`
+
+### API Version Compatibility
+Some functions check the DPC version and use different endpoints:
+```powershell
+$ver = Get-JuribaDPCVersion -Instance $Instance -MinimumVersion "5.14"
+if ($ver) {
+    $uri = "{0}/apiv2/imports/{1}" -f $Instance, $ImportId     # 5.14+
+} else {
+    $uri = "{0}/apiv2/imports/devices/{1}" -f $Instance, $ImportId  # older
+}
+```
+
+### Error Handling
+- Wrap API calls in `try`/`catch` with `Write-Error $_`.
+- For specific HTTP status codes (e.g., 409 conflict), provide a descriptive error message.
+- Validate required inputs early with `throw` for logic errors.
+
+### ShouldProcess
+- All mutating functions (`New-`, `Set-`, `Remove-`) must use `[CmdletBinding(SupportsShouldProcess)]`.
+- Wrap the API call: `if ($PSCmdlet.ShouldProcess($IdentifyingValue)) { ... }`
+- `Get-` functions do not need ShouldProcess.
+
+### Parameter Sets
+- Use `DefaultParameterSetName` when a function supports mutually exclusive lookup methods (e.g., by Id vs. by Name).
+- Mark each exclusive parameter with its `ParameterSetName`.
+
+### PSScriptAnalyzer Suppressions
+- Use `[Diagnostics.CodeAnalysis.SuppressMessageAttribute("RuleName", "")]` when necessary (e.g., `PSAvoidGlobalVars` in `Connect-Juriba`).
+
+## Code Style
+
+- 4-space indentation
+- Opening braces on the same line as the statement
+- `$camelCase` for local variables
+- `$PascalCase` for parameters
+- String formatting with `-f` operator (not string interpolation) for URI construction
+- Comment-based help inside the function, after the alias declaration
+- One function per file, filename matches function name exactly

--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.13.0'
+    ModuleVersion     = '1.1.14.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -217,7 +217,8 @@
         'Start-JuribaETLJob',
         'Stop-JuribaETLJob',
         'Update-ApplicationOwner',
-        'Set-JuribaCustomFieldValue'
+        'Set-JuribaCustomFieldValue',
+        'Wait-JuribaImportJob'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Juriba.DPC/Public/New-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/New-JuribaImportDevice.ps1
@@ -25,8 +25,15 @@ function New-JuribaImportDevice {
 
         Json payload with updated device details.
 
+        .PARAMETER Async
+
+        Optional. Send bulk requests asynchronously. Returns the job URI for polling with Wait-JuribaImportJob. Requires DPC 5.17 or later. Only applies to bulk requests.
+
         .EXAMPLE
         PS> New-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
+
+        .EXAMPLE
+        PS> New-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Async -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
     #>
 
     [CmdletBinding(SupportsShouldProcess)]
@@ -43,7 +50,9 @@ function New-JuribaImportDevice {
         ErrorMessage = "JsonBody is not valid json or does not contain a uniqueIdentifier"
         )]
         [parameter(Mandatory=$true)]
-        [string]$JsonBody
+        [string]$JsonBody,
+        [parameter(Mandatory=$false)]
+        [switch]$Async
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -60,8 +69,17 @@ function New-JuribaImportDevice {
             $uri = "{0}/apiv2/imports/{1}/devices" -f $Instance, $ImportId
             $bulkuri = "{0}/apiv2/imports/{1}/devices/`$bulk" -f $Instance, $ImportId
         }
+
+        if ($Async) {
+            $asyncVer = Get-JuribaDPCVersion -Instance $Instance -MinimumVersion "5.17"
+            if (-not $asyncVer) {
+                throw "The -Async switch requires DPC version 5.17 or later."
+            }
+            $bulkuri += "?async"
+        }
+
         $headers = @{'x-api-key' = $APIKey}
-    
+
         try {
             if (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -eq 1)) {
                 $result = Invoke-RestMethod -Uri $uri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
@@ -69,15 +87,24 @@ function New-JuribaImportDevice {
             }
             elseif (($PSCmdlet.ShouldProcess(($JsonBody | ConvertFrom-Json).uniqueIdentifier)) -and (($JsonBody | ConvertFrom-Json).Length -gt 1)) {
                 <# Bulk operation request #>
-                $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
-                return $result
+                if ($Async) {
+                    $response = Invoke-WebRequest -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                    if ($response.Headers.Location.Length -gt 0) {
+                        return $response.Headers.Location
+                    } else {
+                        throw "No job location returned in async response headers."
+                    }
+                } else {
+                    $result = Invoke-RestMethod -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                    return $result
+                }
             }
         }
         catch {
             Write-Error $_
         }
 
-    } 
+    }
     else {
         Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
     }

--- a/Juriba.DPC/Public/New-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/New-JuribaImportDevice.ps1
@@ -37,6 +37,7 @@ function New-JuribaImportDevice {
     #>
 
     [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([String])]
     param (
         [Parameter(Mandatory=$false)]
         [string]$Instance,

--- a/Juriba.DPC/Public/New-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/New-JuribaImportDevice.ps1
@@ -89,8 +89,8 @@ function New-JuribaImportDevice {
                 <# Bulk operation request #>
                 if ($Async) {
                     $response = Invoke-WebRequest -Uri $bulkuri -Method POST -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
-                    if ($response.Headers.Location.Length -gt 0) {
-                        return $response.Headers.Location
+                    if ($response.Headers['Location']) {
+                        return [string]$response.Headers['Location'][0]
                     } else {
                         throw "No job location returned in async response headers."
                     }

--- a/Juriba.DPC/Public/Remove-JuribaImportApplication.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportApplication.ps1
@@ -3,10 +3,10 @@ function Remove-JuribaImportApplication {
     [alias("Remove-DwImportApplication")]
     <#
         .SYNOPSIS
-        Deletes an application in the import API.
+        Deletes an application in the import API. Provide a list of JSON objects in request payload to use bulk functionality (Max 1000 objects per request).
 
         .DESCRIPTION
-        Deletes an application in the import API.
+        Deletes an application in the import API. Provide a list of JSON objects in request payload to use bulk functionality (Max 1000 objects per request).
         Takes the ImportId and UniqueIdentifier as an input.
 
         .PARAMETER Instance
@@ -19,14 +19,21 @@ function Remove-JuribaImportApplication {
 
         .PARAMETER UniqueIdentifier
 
-        UniqueIdentifier for the application.
+        Optional. UniqueIdentifier for the application. Optional only when submitting a bulk request (JsonBody to be provided instead).
 
         .PARAMETER ImportId
 
         ImportId for the application.
 
+        .PARAMETER JsonBody
+
+        Optional. Json payload for bulk deletion. Provide an array of URI strings for each object to be deleted (Max 1000 objects per request).
+
         .EXAMPLE
         PS> Remove-JuribaImportApplication -ImportId 1 -UniqueIdentifier "app123" -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
+
+        .EXAMPLE
+        PS> Remove-JuribaImportApplication -ImportId 1 -JsonBody $jsonBody -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
     #>
 
@@ -36,10 +43,17 @@ function Remove-JuribaImportApplication {
         [string]$Instance,
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory=$false)]
         [string]$UniqueIdentifier,
         [parameter(Mandatory=$true)]
-        [int]$ImportId
+        [int]$ImportId,
+        [ValidateScript({
+            Test-Json $_
+        },
+        ErrorMessage = "JsonBody is not valid json."
+        )]
+        [parameter(Mandatory=$false)]
+        [string]$JsonBody
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -51,15 +65,25 @@ function Remove-JuribaImportApplication {
         $ver = Get-JuribaDPCVersion -Instance $instance -MinimumVersion "5.14"
         if ($ver) {
             $uri = "{0}/apiv2/imports/{1}/applications/{2}" -f $Instance, $ImportId, $UniqueIdentifier
+            $bulkuri = "{0}/apiv2/imports/{1}/applications/`$bulk" -f $Instance, $ImportId
         } else {
             $uri = "{0}/apiv2/imports/applications/{1}/items/{2}" -f $Instance, $ImportId, $UniqueIdentifier
+            $bulkuri = "{0}/apiv2/imports/applications/{1}/items/`$bulk" -f $Instance, $ImportId
         }
         $headers = @{'x-api-key' = $APIKey}
-    
+
         try {
-            if ($PSCmdlet.ShouldProcess($UniqueIdentifier)) {
-                $result = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
-                return $result
+            if ($UniqueIdentifier) {
+                if ($PSCmdlet.ShouldProcess($UniqueIdentifier)) {
+                    $result = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
+                    return $result
+                }
+            }
+            elseif ($JsonBody) {
+                if ($PSCmdlet.ShouldProcess($ImportId)) {
+                    $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                    return $result
+                }
             }
         }
         catch {

--- a/Juriba.DPC/Public/Remove-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportDevice.ps1
@@ -29,11 +29,18 @@ function Remove-JuribaImportDevice {
 
         Optional. Json payload for bulk deletion. Provide an array of URI strings for each object to be deleted (Max 1000 objects per request).
 
+        .PARAMETER Async
+
+        Optional. Send bulk requests asynchronously. Returns the job URI for polling with Wait-JuribaImportJob. Requires DPC 5.17 or later. Only applies to bulk requests.
+
         .EXAMPLE
         PS> Remove-JuribaImportDevice -ImportId 1 -UniqueIdentifier "w123abc" -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
         .EXAMPLE
         PS> Remove-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
+
+        .EXAMPLE
+        PS> Remove-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Async -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
     #>
 
@@ -53,7 +60,9 @@ function Remove-JuribaImportDevice {
         ErrorMessage = "JsonBody is not valid json."
         )]
         [parameter(Mandatory=$false)]
-        [string]$JsonBody
+        [string]$JsonBody,
+        [parameter(Mandatory=$false)]
+        [switch]$Async
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -70,6 +79,14 @@ function Remove-JuribaImportDevice {
             $uri = "{0}/apiv2/imports/devices/{1}/items/{2}" -f $Instance, $ImportId, $UniqueIdentifier
             $bulkuri = "{0}/apiv2/imports/devices/{1}/items/`$bulk" -f $Instance, $ImportId
         }
+        if ($Async) {
+            $asyncVer = Get-JuribaDPCVersion -Instance $Instance -MinimumVersion "5.17"
+            if (-not $asyncVer) {
+                throw "The -Async switch requires DPC version 5.17 or later."
+            }
+            $bulkuri += "?async"
+        }
+
         $headers = @{'x-api-key' = $APIKey}
 
         try {
@@ -81,8 +98,17 @@ function Remove-JuribaImportDevice {
             }
             elseif ($JsonBody) {
                 if ($PSCmdlet.ShouldProcess($ImportId)) {
-                    $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
-                    return $result
+                    if ($Async) {
+                        $response = Invoke-WebRequest -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                        if ($response.Headers.Location.Length -gt 0) {
+                            return $response.Headers.Location
+                        } else {
+                            throw "No job location returned in async response headers."
+                        }
+                    } else {
+                        $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                        return $result
+                    }
                 }
             }
         }

--- a/Juriba.DPC/Public/Remove-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportDevice.ps1
@@ -3,10 +3,10 @@ function Remove-JuribaImportDevice {
     [alias("Remove-DwImportDevice")]
     <#
         .SYNOPSIS
-        Deletes a device in the import API.
+        Deletes a device in the import API. Provide a list of JSON objects in request payload to use bulk functionality (Max 1000 objects per request).
 
         .DESCRIPTION
-        Deletes a device in the import API.
+        Deletes a device in the import API. Provide a list of JSON objects in request payload to use bulk functionality (Max 1000 objects per request).
         Takes the ImportId and UniqueIdentifier as an input.
 
         .PARAMETER Instance
@@ -19,14 +19,21 @@ function Remove-JuribaImportDevice {
 
         .PARAMETER UniqueIdentifier
 
-        UniqueIdentifier for the device.
+        Optional. UniqueIdentifier for the device. Optional only when submitting a bulk request (JsonBody to be provided instead).
 
         .PARAMETER ImportId
 
         ImportId for the device.
 
+        .PARAMETER JsonBody
+
+        Optional. Json payload for bulk deletion. Provide an array of URI strings for each object to be deleted (Max 1000 objects per request).
+
         .EXAMPLE
         PS> Remove-JuribaImportDevice -ImportId 1 -UniqueIdentifier "w123abc" -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
+
+        .EXAMPLE
+        PS> Remove-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
     #>
 
@@ -36,10 +43,17 @@ function Remove-JuribaImportDevice {
         [string]$Instance,
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory=$false)]
         [string]$UniqueIdentifier,
         [parameter(Mandatory=$true)]
-        [int]$ImportId
+        [int]$ImportId,
+        [ValidateScript({
+            Test-Json $_
+        },
+        ErrorMessage = "JsonBody is not valid json."
+        )]
+        [parameter(Mandatory=$false)]
+        [string]$JsonBody
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -51,15 +65,25 @@ function Remove-JuribaImportDevice {
         $ver = Get-JuribaDPCVersion -Instance $instance -MinimumVersion "5.14"
         if ($ver) {
             $uri = "{0}/apiv2/imports/{1}/devices/{2}" -f $Instance, $ImportId, $UniqueIdentifier
+            $bulkuri = "{0}/apiv2/imports/{1}/devices/`$bulk" -f $Instance, $ImportId
         } else {
             $uri = "{0}/apiv2/imports/devices/{1}/items/{2}" -f $Instance, $ImportId, $UniqueIdentifier
+            $bulkuri = "{0}/apiv2/imports/devices/{1}/items/`$bulk" -f $Instance, $ImportId
         }
         $headers = @{'x-api-key' = $APIKey}
-    
+
         try {
-            if ($PSCmdlet.ShouldProcess($UniqueIdentifier)) {
-                $result = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
-                return $result
+            if ($UniqueIdentifier) {
+                if ($PSCmdlet.ShouldProcess($UniqueIdentifier)) {
+                    $result = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
+                    return $result
+                }
+            }
+            elseif ($JsonBody) {
+                if ($PSCmdlet.ShouldProcess($ImportId)) {
+                    $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                    return $result
+                }
             }
         }
         catch {

--- a/Juriba.DPC/Public/Remove-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportDevice.ps1
@@ -29,18 +29,11 @@ function Remove-JuribaImportDevice {
 
         Optional. Json payload for bulk deletion. Provide an array of URI strings for each object to be deleted (Max 1000 objects per request).
 
-        .PARAMETER Async
-
-        Optional. Send bulk requests asynchronously. Returns the job URI for polling with Wait-JuribaImportJob. Requires DPC 5.17 or later. Only applies to bulk requests.
-
         .EXAMPLE
         PS> Remove-JuribaImportDevice -ImportId 1 -UniqueIdentifier "w123abc" -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
         .EXAMPLE
         PS> Remove-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
-
-        .EXAMPLE
-        PS> Remove-JuribaImportDevice -ImportId 1 -JsonBody $jsonBody -Async -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
     #>
 
@@ -60,9 +53,7 @@ function Remove-JuribaImportDevice {
         ErrorMessage = "JsonBody is not valid json."
         )]
         [parameter(Mandatory=$false)]
-        [string]$JsonBody,
-        [parameter(Mandatory=$false)]
-        [switch]$Async
+        [string]$JsonBody
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -79,14 +70,6 @@ function Remove-JuribaImportDevice {
             $uri = "{0}/apiv2/imports/devices/{1}/items/{2}" -f $Instance, $ImportId, $UniqueIdentifier
             $bulkuri = "{0}/apiv2/imports/devices/{1}/items/`$bulk" -f $Instance, $ImportId
         }
-        if ($Async) {
-            $asyncVer = Get-JuribaDPCVersion -Instance $Instance -MinimumVersion "5.17"
-            if (-not $asyncVer) {
-                throw "The -Async switch requires DPC version 5.17 or later."
-            }
-            $bulkuri += "?async"
-        }
-
         $headers = @{'x-api-key' = $APIKey}
 
         try {
@@ -98,17 +81,8 @@ function Remove-JuribaImportDevice {
             }
             elseif ($JsonBody) {
                 if ($PSCmdlet.ShouldProcess($ImportId)) {
-                    if ($Async) {
-                        $response = Invoke-WebRequest -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
-                        if ($response.Headers.Location.Length -gt 0) {
-                            return $response.Headers.Location
-                        } else {
-                            throw "No job location returned in async response headers."
-                        }
-                    } else {
-                        $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
-                        return $result
-                    }
+                    $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                    return $result
                 }
             }
         }

--- a/Juriba.DPC/Public/Remove-JuribaImportDeviceFeedAllItem.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportDeviceFeedAllItem.ps1
@@ -21,6 +21,10 @@ function Remove-JuribaImportDeviceFeedAllItem {
 
         The Id of the device feed to be deleted.
 
+        .PARAMETER Async
+
+        Optional. Send the request asynchronously. Returns the job URI for polling with Wait-JuribaImportJob. Requires DPC 5.17 or later.
+
         .EXAMPLE
 
         PS> Remove-JuribaImportDeviceFeedAllItem -ImportId 1 -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
@@ -28,6 +32,10 @@ function Remove-JuribaImportDeviceFeedAllItem {
         .EXAMPLE
 
         PS> Remove-JuribaImportDeviceFeedAllItem -Confirm:$false -ImportId 1 -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
+
+        .EXAMPLE
+
+        PS> Remove-JuribaImportDeviceFeedAllItem -ImportId 1 -Async -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
     #>
     [CmdletBinding(
@@ -40,7 +48,9 @@ function Remove-JuribaImportDeviceFeedAllItem {
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
         [parameter(Mandatory=$true)]
-        [int]$ImportId
+        [int]$ImportId,
+        [parameter(Mandatory=$false)]
+        [switch]$Async
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -55,12 +65,29 @@ function Remove-JuribaImportDeviceFeedAllItem {
         } else {
             $uri = "{0}/apiv2/imports/devices/{1}/items" -f $Instance, $ImportId
         }
+        if ($Async) {
+            $asyncVer = Get-JuribaDPCVersion -Instance $Instance -MinimumVersion "5.17"
+            if (-not $asyncVer) {
+                throw "The -Async switch requires DPC version 5.17 or later."
+            }
+            $uri += "?async"
+        }
+
         $headers = @{'x-api-key' = $APIKey}
-    
+
         try {
             if ($PSCmdlet.ShouldProcess($ImportId)) {
-                $result = Invoke-RestMethod -Uri $uri -Method DELETE -Headers $headers
-                return $result
+                if ($Async) {
+                    $response = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
+                    if ($response.Headers['Location']) {
+                        return [string]$response.Headers['Location'][0]
+                    } else {
+                        throw "No job location returned in async response headers."
+                    }
+                } else {
+                    $result = Invoke-RestMethod -Uri $uri -Method DELETE -Headers $headers
+                    return $result
+                }
             }
         }
         catch {

--- a/Juriba.DPC/Public/Remove-JuribaImportDeviceFeedAllItem.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportDeviceFeedAllItem.ps1
@@ -42,6 +42,7 @@ function Remove-JuribaImportDeviceFeedAllItem {
         SupportsShouldProcess,
         ConfirmImpact = 'High'
     )]
+    [OutputType([String])]
     param (
         [Parameter(Mandatory=$false)]
         [string]$Instance,

--- a/Juriba.DPC/Public/Remove-JuribaImportUser.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaImportUser.ps1
@@ -3,10 +3,10 @@ function Remove-JuribaImportUser {
     [alias("Remove-DwImportUser")]
     <#
         .SYNOPSIS
-        Deletes a user in the import API.
+        Deletes a user in the import API. Provide a list of JSON objects in request payload to use bulk functionality (Max 1000 objects per request).
 
         .DESCRIPTION
-        Deletes a user in the import API.
+        Deletes a user in the import API. Provide a list of JSON objects in request payload to use bulk functionality (Max 1000 objects per request).
         Takes the ImportId and UniqueIdentifier as an input.
 
         .PARAMETER Instance
@@ -19,14 +19,21 @@ function Remove-JuribaImportUser {
 
         .PARAMETER UniqueIdentifier
 
-        UniqueIdentifier for the user.
+        Optional. UniqueIdentifier for the user. Optional only when submitting a bulk request (JsonBody to be provided instead).
 
         .PARAMETER ImportId
 
         ImportId for the user.
 
+        .PARAMETER JsonBody
+
+        Optional. Json payload for bulk deletion. Provide an array of URI strings for each object to be deleted (Max 1000 objects per request).
+
         .EXAMPLE
         PS> Remove-JuribaImportUser -ImportId 1 -UniqueIdentifier "app123" -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
+
+        .EXAMPLE
+        PS> Remove-JuribaImportUser -ImportId 1 -JsonBody $jsonBody -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx"
 
     #>
 
@@ -36,10 +43,17 @@ function Remove-JuribaImportUser {
         [string]$Instance,
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory=$false)]
         [string]$UniqueIdentifier,
         [parameter(Mandatory=$true)]
-        [int]$ImportId
+        [int]$ImportId,
+        [ValidateScript({
+            Test-Json $_
+        },
+        ErrorMessage = "JsonBody is not valid json."
+        )]
+        [parameter(Mandatory=$false)]
+        [string]$JsonBody
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -51,15 +65,25 @@ function Remove-JuribaImportUser {
         $ver = Get-JuribaDPCVersion -Instance $instance -MinimumVersion "5.14"
         if ($ver) {
             $uri = "{0}/apiv2/imports/{1}/users/{2}" -f $Instance, $ImportId, $UniqueIdentifier
+            $bulkuri = "{0}/apiv2/imports/{1}/users/`$bulk" -f $Instance, $ImportId
         } else {
             $uri = "{0}/apiv2/imports/users/{1}/items/{2}" -f $Instance, $ImportId, $UniqueIdentifier
+            $bulkuri = "{0}/apiv2/imports/users/{1}/items/`$bulk" -f $Instance, $ImportId
         }
         $headers = @{'x-api-key' = $APIKey}
-    
+
         try {
-            if ($PSCmdlet.ShouldProcess($UniqueIdentifier)) {
-                $result = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
-                return $result
+            if ($UniqueIdentifier) {
+                if ($PSCmdlet.ShouldProcess($UniqueIdentifier)) {
+                    $result = Invoke-WebRequest -Uri $uri -Method DELETE -Headers $headers
+                    return $result
+                }
+            }
+            elseif ($JsonBody) {
+                if ($PSCmdlet.ShouldProcess($ImportId)) {
+                    $result = Invoke-RestMethod -Uri $bulkuri -Method DELETE -Headers $headers -ContentType "application/json" -Body ([System.Text.Encoding]::UTF8.GetBytes($JsonBody))
+                    return $result
+                }
             }
         }
         catch {

--- a/Juriba.DPC/Public/Set-JuribaImportApplication.ps1
+++ b/Juriba.DPC/Public/Set-JuribaImportApplication.ps1
@@ -40,7 +40,7 @@ function Set-JuribaImportApplication {
         [string]$Instance,
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
-        [parameter(Mandatory=$true)]
+        [parameter(Mandatory=$false)]
         [string]$UniqueIdentifier,
         [parameter(Mandatory=$true)]
         [int]$ImportId,

--- a/Juriba.DPC/Public/Wait-JuribaImportJob.ps1
+++ b/Juriba.DPC/Public/Wait-JuribaImportJob.ps1
@@ -1,0 +1,77 @@
+#Requires -Version 7
+function Wait-JuribaImportJob {
+    <#
+        .SYNOPSIS
+        Polls an async import job until it completes or fails.
+
+        .DESCRIPTION
+        Takes a job URI returned by an async bulk import request and polls it until the job status
+        is no longer InProgress. Returns the completed job details including per-item results.
+
+        .PARAMETER Instance
+
+        Optional. Juriba instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dashworks.app:8443
+
+        .PARAMETER APIKey
+
+        Optional. API key to be provided if not authenticating using Connect-Juriba.
+
+        .PARAMETER JobUri
+
+        The job URI returned in the Location header of an async bulk import request.
+
+        .PARAMETER PollIntervalMs
+
+        Optional. Polling interval in milliseconds. Default is 500.
+
+        .OUTPUTS
+        Job details object containing requestId, status, error, and result properties.
+
+        .EXAMPLE
+        PS> $jobUri = New-JuribaImportDevice @DwParams -ImportId 1 -JsonBody $jsonBody -Async
+        PS> $result = Wait-JuribaImportJob @DwParams -JobUri $jobUri
+
+        .EXAMPLE
+        PS> $jobUris = foreach ($batch in $batches) { New-JuribaImportDevice @DwParams -ImportId 1 -JsonBody $batch -Async }
+        PS> $results = $jobUris | ForEach-Object { Wait-JuribaImportJob @DwParams -JobUri $_ }
+
+    #>
+
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$false)]
+        [string]$Instance,
+        [Parameter(Mandatory=$false)]
+        [string]$APIKey,
+        [parameter(Mandatory=$true)]
+        [string]$JobUri,
+        [parameter(Mandatory=$false)]
+        [int]$PollIntervalMs = 500
+    )
+    if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
+        $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
+        $Instance = $dwConnection.instance
+    }
+
+    if ($APIKey -and $Instance) {
+        $headers = @{'x-api-key' = $APIKey}
+
+        try {
+            $jobDetails = Invoke-RestMethod -Uri $JobUri -Method GET -Headers $headers
+            while ($jobDetails.status -eq "InProgress") {
+                Start-Sleep -Milliseconds $PollIntervalMs
+                $jobDetails = Invoke-RestMethod -Uri $JobUri -Method GET -Headers $headers
+            }
+            if ($jobDetails.status -eq "Failed") {
+                Write-Error ("Async job {0} failed: {1}" -f $jobDetails.requestId, $jobDetails.error)
+            }
+            return $jobDetails
+        }
+        catch {
+            Write-Error $_
+        }
+
+    } else {
+        Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
+    }
+}

--- a/Juriba.DPC/Public/Wait-JuribaImportJob.ps1
+++ b/Juriba.DPC/Public/Wait-JuribaImportJob.ps1
@@ -58,7 +58,7 @@ function Wait-JuribaImportJob {
 
         try {
             $jobDetails = Invoke-RestMethod -Uri $JobUri -Method GET -Headers $headers
-            while ($jobDetails.status -eq "InProgress") {
+            while ($jobDetails.status -notin @("Completed", "Failed")) {
                 Start-Sleep -Milliseconds $PollIntervalMs
                 $jobDetails = Invoke-RestMethod -Uri $JobUri -Method GET -Headers $headers
             }


### PR DESCRIPTION
## Project Setup
- **CLAUDE.md** — Created with project structure, conventions, function template, and patterns for Claude Code assistance
- **.gitignore** — Added `.claude/` and `.tests/`

## Function Changes

### Set-JuribaImportApplication
- `UniqueIdentifier` changed from mandatory to optional (matching `Set-JuribaImportDevice` and `Set-JuribaImportUser`)

### Remove-JuribaImportDevice / Remove-JuribaImportUser / Remove-JuribaImportApplication
- `UniqueIdentifier` made optional
- Added `JsonBody` parameter for bulk deletion via `$bulk` endpoint

### New-JuribaImportDevice
- Added `-Async` switch for bulk POST requests
- Requires DPC 5.17+, returns a job URI for polling with `Wait-JuribaImportJob`

### Remove-JuribaImportDeviceFeedAllItem
- Added `-Async` switch for delete-all requests
- Requires DPC 5.17+, returns a job URI for polling with `Wait-JuribaImportJob`

### Wait-JuribaImportJob (new)
- Polls an async job URI until it reaches `Completed` or `Failed`
- Accepts optional `-PollIntervalMs` parameter (default 500ms)

### Juriba.DPC.psd1
- Added `Wait-JuribaImportJob` to `FunctionsToExport`
- Bumped `ModuleVersion` to `1.1.14.0`
