### PR TITLE
Bulk update task values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Examples/            - Example scripts organized by integration type
 - Pattern: `[Verb]-Juriba[Entity]` (e.g., `Get-JuribaTeam`, `New-JuribaImportDevice`)
 - Use approved PowerShell verbs: `Get`, `New`, `Set`, `Remove`, `Add`, `Connect`, `Disconnect`, `Invoke`, `Export`, `Start`, `Stop`, `Update`
 - Existing functions have a legacy `Dw` alias from when the module was named `Juriba.Dashworks` (e.g., `[alias("Get-DwTeam")]`). New functions do not need an alias.
+- The product is called **Juriba DPC** (not Dashworks). Use "Juriba DPC" in all new function descriptions and documentation. Existing functions may still reference "Dashworks" but new code should not.
 
 ## Function Template
 

--- a/Examples/Projects/Bulk Task Value Update from CSV.ps1
+++ b/Examples/Projects/Bulk Task Value Update from CSV.ps1
@@ -1,0 +1,106 @@
+<#
+
+.SYNOPSIS
+A sample script to bulk update task values across multiple objects from a CSV file.
+
+.DESCRIPTION
+A sample script demonstrating how to use Set-JuribaTaskValueBulk and
+Get-JuribaTaskBulkUpdateLog to update task values for many objects in a
+single API call per task.
+
+The script reads a CSV file containing object keys, task IDs, task types, and
+values, groups the updates by task, and performs a bulk update for each group.
+
+CSV format:
+    ObjectKey,TaskId,TaskType,Value
+    9141,13188,Select,5
+    5123,13188,Select,5
+    9141,13265,Date,2026-04-15
+    5123,13760,Text,Migrated
+
+TaskType must be one of: Select, Date, Text
+
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$Instance,
+    [Parameter(Mandatory=$true)]
+    [string]$APIKey,
+    [Parameter(Mandatory=$true)]
+    [int]$ProjectId,
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("Device", "User", "Application", "Mailbox")]
+    [string]$ObjectType,
+    [Parameter(Mandatory=$true)]
+    [string]$Path
+)
+
+#Requires -Version 7
+#Requires -Module @{ ModuleName = 'Juriba.DPC'; ModuleVersion = '1.1.15' }
+
+$juribaParams = @{
+    Instance = $Instance
+    APIKey   = $APIKey
+}
+
+# Import the CSV and group by TaskId
+$updates = Import-Csv -Path $Path
+$grouped = $updates | Group-Object TaskId
+
+Write-Host "Found $($grouped.Count) task(s) to update across $($updates.Count) total rows."
+
+$operations = @()
+
+foreach ($group in $grouped) {
+    $taskId   = [int]$group.Name
+    $items    = $group.Group | ForEach-Object { [int]$_.ObjectKey }
+    $sample   = $group.Group[0]
+    $taskType = $sample.TaskType
+
+    Write-Host "Updating TaskId $taskId ($taskType) for $($items.Count) objects..."
+
+    $bulkParams = @{
+        ProjectId  = $ProjectId
+        TaskId     = $taskId
+        ObjectType = $ObjectType
+        Objects    = $items
+    }
+
+    switch ($taskType) {
+        "Select" { $bulkParams['SelectValue'] = [int]$sample.Value }
+        "Date"   { $bulkParams['DateValue'] = $sample.Value }
+        "Text"   { $bulkParams['TextValue'] = $sample.Value }
+        default  { Write-Warning "Unknown TaskType '$taskType' for TaskId $taskId. Skipping."; continue }
+    }
+
+    $result = Set-JuribaTaskValueBulk @juribaParams @bulkParams
+
+    Write-Host "  Submitted: opId=$($result.opId), itemsSent=$($result.itemsCountSent), itemsAccepted=$($result.itemsCountAccepted)"
+    $operations += $result
+}
+
+# Poll for completion of all operations
+Write-Host "`nChecking bulk update logs..."
+
+foreach ($op in $operations) {
+    $maxAttempts = 30
+    $attempt = 0
+    do {
+        Start-Sleep -Seconds 2
+        $log = Get-JuribaTaskBulkUpdateLog @juribaParams -OperationId $op.opId
+        $attempt++
+    } until ($log.results.outcome.status -eq 2 -or $attempt -ge $maxAttempts)
+
+    if ($log.results.outcome.status -eq 2) {
+        Write-Host "  opId $($op.opId): $($log.results.outcome.text) - Task '$($log.results.taskName)' updated $($log.results.objectCount) objects"
+    } else {
+        Write-Warning "  opId $($op.opId): Did not complete within expected time. Last status: $($log.results.outcome.text)"
+        if ($log.results.error) {
+            Write-Warning "  Error: $($log.results.error)"
+        }
+    }
+}
+
+Write-Host "`nBulk update complete."

--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.15.0'
+    ModuleVersion     = '1.1.16.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.14.0'
+    ModuleVersion     = '1.1.15.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -116,6 +116,7 @@
         'Get-JuribaSessionUser',
         'Get-JuribaTag',
         'Get-JuribaTask',
+        'Get-JuribaTaskBulkUpdateLog',
         'Get-JuribaTeam',
         'Invoke-JuribaAutomation',
         'New-JuribaAutomation',
@@ -210,6 +211,7 @@
         'Set-JuribaImportVulnerability',
 		'Set-JuribaListTeamUserAccess',
         'Set-JuribaProjectCapacityDetail',
+        'Set-JuribaTaskValueBulk',
         'Set-JuribaTaskValueDate',
         'Set-JuribaTaskValueSelect',
         'Set-JuribaTaskValueText',

--- a/Juriba.DPC/Public/Get-JuribaTaskBulkUpdateLog.ps1
+++ b/Juriba.DPC/Public/Get-JuribaTaskBulkUpdateLog.ps1
@@ -1,0 +1,66 @@
+#requires -Version 7
+function Get-JuribaTaskBulkUpdateLog {
+    <#
+        .SYNOPSIS
+        Returns the log for a bulk task value update operation.
+
+        .DESCRIPTION
+        Returns the status and details of a bulk task value update operation
+        using the Juriba DPC API v1 bulk update log endpoint.
+        Use the opId returned by Set-JuribaTaskValueBulk to check the operation status.
+
+        .PARAMETER Instance
+        Optional. Juriba instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dpc.juriba.app
+
+        .PARAMETER APIKey
+        Optional. API key to be provided if not authenticating using Connect-Juriba.
+
+        .PARAMETER OperationId
+        The operation ID returned by Set-JuribaTaskValueBulk.
+
+        .OUTPUTS
+        The bulk update log object containing taskName, objectCount, outcome, submittedDate, startedDate, completedDate, error, and other details.
+
+        .EXAMPLE
+        PS> Get-JuribaTaskBulkUpdateLog -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxxxx" -OperationId 2003
+
+        .EXAMPLE
+        PS> $result = Set-JuribaTaskValueBulk -ProjectId 49 -TaskId 100 -ObjectType Device -SelectValue 5 -Objects @(9141, 5123)
+        PS> Get-JuribaTaskBulkUpdateLog -OperationId $result.opId
+    #>
+
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Instance,
+
+        [Parameter(Mandatory = $false)]
+        [string]$APIKey,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$OperationId
+    )
+
+    if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
+        $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
+        $Instance = $dwConnection.instance
+    }
+
+    if ($APIKey -and $Instance) {
+        $uri = "{0}/apiv1/bulk-update/logs/{1}" -f $Instance, $OperationId
+        $headers = @{
+            'x-api-key' = $APIKey
+        }
+
+        try {
+            $response = Invoke-WebRequest -Uri $uri -Headers $headers -Method GET
+            $result = $response.Content | ConvertFrom-Json
+            return $result
+        }
+        catch {
+            Write-Error $_
+        }
+    } else {
+        Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
+    }
+}

--- a/Juriba.DPC/Public/Set-JuribaTaskValueBulk.ps1
+++ b/Juriba.DPC/Public/Set-JuribaTaskValueBulk.ps1
@@ -1,0 +1,205 @@
+#requires -Version 7
+function Set-JuribaTaskValueBulk {
+    <#
+        .SYNOPSIS
+        Bulk updates a project task value across multiple objects.
+
+        .DESCRIPTION
+        Updates a single task value for multiple objects in one API call using the
+        Juriba DPC API v1 bulk update endpoint. Supports select, date, and text task types.
+        Returns an operation object with an opId that can be used with Get-JuribaTaskBulkUpdateLog
+        to check the status of the bulk update.
+
+        .PARAMETER Instance
+        Optional. Juriba instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dpc.juriba.app
+
+        .PARAMETER APIKey
+        Optional. API key to be provided if not authenticating using Connect-Juriba.
+
+        .PARAMETER ProjectId
+        The project ID containing the task to be updated.
+
+        .PARAMETER TaskId
+        The ID of the task to be updated.
+
+        .PARAMETER ObjectType
+        The type of objects being updated. Device, User, Application, or Mailbox.
+
+        .PARAMETER Objects
+        An array of object keys to update.
+
+        .PARAMETER SelectValue
+        The select (radio button) value to set the task to.
+
+        .PARAMETER DueDate
+        Optional. An ISO 8601 formatted date string to set as the due date on a select task. e.g. '2026-04-15'
+
+        .PARAMETER TeamId
+        Optional. The team ID to assign on a select task. Can be used with or without OwnerId.
+
+        .PARAMETER OwnerId
+        Optional. The owner user ID (GUID) to assign on a select task. Requires TeamId.
+
+        .PARAMETER DateValue
+        An ISO 8601 formatted date string to set the date task to. e.g. '2026-04-15'
+
+        .PARAMETER SlotId
+        Optional. The capacity slot ID to set on a date task.
+
+        .PARAMETER TextValue
+        The text value to set the task to.
+
+        .OUTPUTS
+        An object containing opId, itemsCountSent, itemsCountAccepted, isEvergreen, and isServiceBrokerEnabled.
+
+        .EXAMPLE
+        PS> Set-JuribaTaskValueBulk -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxxxx" -ProjectId 49 -TaskId 13188 -ObjectType Device -SelectValue 5 -Objects @(9141, 5123, 1)
+
+        .EXAMPLE
+        PS> Set-JuribaTaskValueBulk -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxxxx" -ProjectId 49 -TaskId 13274 -ObjectType Device -SelectValue 1 -TeamId 2836 -OwnerId "971c8e3d-3c65-4e8e-b819-e1b4c8b1ed74" -Objects @(9141, 5123)
+
+        .EXAMPLE
+        PS> Set-JuribaTaskValueBulk -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxxxx" -ProjectId 49 -TaskId 13265 -ObjectType Device -DateValue "2026-04-15" -SlotId 111 -Objects @(9141, 5123)
+
+        .EXAMPLE
+        PS> Set-JuribaTaskValueBulk -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxxxx" -ProjectId 122 -TaskId 13760 -ObjectType Device -TextValue "Hello World" -Objects @(9141, 5123, 1)
+    #>
+
+    [CmdletBinding(DefaultParameterSetName = "Select", SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Instance,
+
+        [Parameter(Mandatory = $false)]
+        [string]$APIKey,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$ProjectId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int]$TaskId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Device", "User", "Application", "Mailbox")]
+        [string]$ObjectType,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [int[]]$Objects,
+
+        # Select parameter set
+        [Parameter(Mandatory = $true, ParameterSetName = 'Select')]
+        [ValidateNotNullOrEmpty()]
+        [int]$SelectValue,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Select')]
+        [string]$DueDate,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Select')]
+        [int]$TeamId,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Select')]
+        [string]$OwnerId,
+
+        # Date parameter set
+        [Parameter(Mandatory = $true, ParameterSetName = 'Date')]
+        [ValidateNotNullOrEmpty()]
+        [string]$DateValue,
+
+        [Parameter(Mandatory = $false, ParameterSetName = 'Date')]
+        [int]$SlotId,
+
+        # Text parameter set
+        [Parameter(Mandatory = $true, ParameterSetName = 'Text')]
+        [ValidateNotNullOrEmpty()]
+        [string]$TextValue
+    )
+
+    # Validate that OwnerId is not provided without TeamId
+    if ($OwnerId -and -not $TeamId) {
+        throw "OwnerId cannot be set without TeamId. Please provide a TeamId."
+    }
+
+    if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
+        $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
+        $Instance = $dwConnection.instance
+    }
+
+    if ($APIKey -and $Instance) {
+        $path = switch ($ObjectType) {
+            "Device"      { "devices" }
+            "User"        { "users" }
+            "Application" { "applications" }
+            "Mailbox"     { "mailboxes" }
+        }
+
+        $uri = "{0}/apiv1/bulkupdate/{1}/{2}" -f $Instance, $path, $ProjectId
+        $headers = @{
+            'x-api-key'    = $APIKey
+            'content-type' = 'application/json'
+        }
+
+        $body = @{
+            'action' = 'taskUpdate'
+            'taskId' = $TaskId
+            'url'    = '/bulkupdate/{0}/{1}' -f $path, $ProjectId
+            'items'  = @($Objects)
+        }
+
+        switch ($PSCmdlet.ParameterSetName) {
+            'Select' {
+                $body['setValue'] = $true
+                $body['objectValue'] = $SelectValue
+
+                if ($DueDate) {
+                    $body['setDate'] = $true
+                    $body['dateValue'] = $DueDate
+                }
+
+                if ($TeamId) {
+                    $body['setOwner'] = $true
+                    $body['updateBucketTeam'] = $true
+                    $body['updateBucketOwner'] = $true
+                    $body['assignedTeamId'] = $TeamId
+
+                    if ($OwnerId) {
+                        $body['assignedUserId'] = $OwnerId
+                    }
+                }
+            }
+            'Date' {
+                $body['setDate'] = $true
+                $body['dateValue'] = $DateValue
+
+                if ($SlotId) {
+                    $body['setSlot'] = $true
+                    $body['capacitySlotId'] = $SlotId
+                } else {
+                    $body['setSlot'] = $false
+                }
+            }
+            'Text' {
+                $body['setValue'] = $true
+                $body['objectValue'] = $TextValue
+            }
+        }
+
+        $jsonBody = $body | ConvertTo-Json
+        $encodedBody = [System.Text.Encoding]::UTF8.GetBytes($jsonBody)
+
+        try {
+            if ($PSCmdlet.ShouldProcess("TaskId: $TaskId, Objects: $($Objects.Count)")) {
+                $response = Invoke-WebRequest -Uri $uri -Headers $headers -Body $encodedBody -Method PATCH
+                $result = $response.Content | ConvertFrom-Json
+                return $result
+            }
+        }
+        catch {
+            Write-Error $_
+        }
+    } else {
+        Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
+    }
+}


### PR DESCRIPTION
## Summary

Adds bulk task value update support to the Juriba.DPC module, addressing [JRB-3912](https://juriba.atlassian.net/browse/JRB-3912). This enables updating a single task value across many objects in one API call, replacing the current pattern of looping through objects individually.

### New functions

- **`Set-JuribaTaskValueBulk`** — Bulk updates a task value for multiple objects via `PATCH /apiv1/bulkupdate/{objectType}/{projectId}`. Supports three parameter sets:
  - **Select** — `SelectValue` (mandatory), with optional `DueDate`, `TeamId`, `OwnerId`
  - **Date** — `DateValue` (mandatory), with optional `SlotId`
  - **Text** — `TextValue` (mandatory)
  - Returns an operation response containing `opId` for status tracking
  - Supports all object types: Device, User, Application, Mailbox

- **`Get-JuribaTaskBulkUpdateLog`** — Retrieves the status of a bulk update operation by `OperationId` via `GET /apiv1/bulk-update/logs/{opId}`

### Other changes

- **Module manifest** — Version bumped to `1.1.15.0`, both functions added to `FunctionsToExport`
- **CLAUDE.md** — Added guidance that new functions should reference "Juriba DPC" not "Dashworks"
- **Example script** — `Examples/Projects/Bulk Task Value Update from CSV.ps1` demonstrates the full workflow: reading a CSV, grouping by task, bulk updating, and polling logs for completion

[JRB-3912]: https://juriba.atlassian.net/browse/JRB-3912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ