### PR TITLE
Add list access management functions

### DIFF
--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.18.0'
+    ModuleVersion     = '1.1.17.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.16.0'
+    ModuleVersion     = '1.1.18.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -183,6 +183,7 @@
         'Remove-JuribaImportUserFeedAllItem',
         'Remove-JuribaImportVulnerability',
         'Remove-JuribaList',
+        'Remove-JuribaListTeamUserAccess',
         'Remove-JuribaTag',
         'Remove-JuribaTaskValueDate',
         'Remove-JuribaTaskValueText',
@@ -209,7 +210,8 @@
         'Set-JuribaImportMailboxFeed',
         'Set-JuribaImportUser',
         'Set-JuribaImportVulnerability',
-		'Set-JuribaListTeamUserAccess',
+        'Set-JuribaListAccessType',
+        'Set-JuribaListTeamUserAccess',
         'Set-JuribaProjectCapacityDetail',
         'Set-JuribaTaskValueBulk',
         'Set-JuribaTaskValueDate',

--- a/Juriba.DPC/Public/New-JuribaList.ps1
+++ b/Juriba.DPC/Public/New-JuribaList.ps1
@@ -35,19 +35,19 @@ Function New-JuribaList {
 
         .PARAMETER ObjectType
 
-        Base object type for the new list. Accepts one of: "Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplciationDevice"
+        Base object type for the new list. Accepts one of: "Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice"
 
         .PARAMETER SharedViewAccessType
 
-        Sets the View Access permissions for the list. Accepts one of: "Owner", "Eveyone". Optional, if ommited "Owner" is used.
+        Sets the View Access permissions for the list. Accepts one of: "Owner", "Everyone". Optional, if ommited "Owner" is used.
 
         .PARAMETER SharedEditAccessType
 
-        Sets the Edit Access permissions for the list. Accepts one of: "Owner", "Eveyone". Optional, if ommited "Owner" is used.
+        Sets the Edit Access permissions for the list. Accepts one of: "Owner", "Everyone". Optional, if ommited "Owner" is used.
 
         .PARAMETER SharedAdminAccessType
 
-        Sets the Admin Access permissions for the list. Accepts one of: "Owner", "Eveyone". Optional, if ommited "Owner" is used.
+        Sets the Admin Access permissions for the list. Accepts one of: "Owner", "Everyone". Optional, if ommited "Owner" is used.
 
         .EXAMPLE
 
@@ -81,7 +81,7 @@ Function New-JuribaList {
         [Parameter(Mandatory = $true)]
         [string]$QueryString,
         [Parameter(Mandatory = $true)]
-        [ValidateSet("Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplciationDevice")]
+        [ValidateSet("Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice")]
         [string]$ObjectType,
         [Parameter(Mandatory = $false)]
         [ValidateSet("Owner", "Everyone")]

--- a/Juriba.DPC/Public/Remove-JuribaList.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaList.ps1
@@ -7,7 +7,7 @@ Function Remove-JuribaList {
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
         [Parameter(Mandatory = $true)]
-        [ValidateSet("Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplciationDevice")]
+        [ValidateSet("Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice")]
         [string]$ObjectType,
         [Parameter(Mandatory=$true)]
         [int]$ListId

--- a/Juriba.DPC/Public/Remove-JuribaListTeamUserAccess.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaListTeamUserAccess.ps1
@@ -1,0 +1,96 @@
+#requires -Version 7
+function Remove-JuribaListTeamUserAccess {
+    <#
+        .SYNOPSIS
+        Revokes a user or team's access to a list.
+
+        .DESCRIPTION
+        Uses ApiV1 to delete a previously-granted user or team access record from
+        a list. Pair with Set-JuribaListTeamUserAccess (which adds grants) and
+        Set-JuribaListAccessType (which controls the list's overall access mode).
+
+        .PARAMETER Instance
+        Optional. Juriba instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dpc.juriba.app
+
+        .PARAMETER APIKey
+        Optional. API key to be provided if not authenticating using Connect-Juriba.
+
+        .PARAMETER ObjectType
+        Base object type for the list. Accepts one of: "Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice"
+
+        .PARAMETER ListId
+        The id of the list whose grant is being removed.
+
+        .PARAMETER UserId
+        The id of the user whose access should be revoked. Mutually exclusive with -TeamId.
+
+        .PARAMETER TeamId
+        The id of the team whose access should be revoked. Mutually exclusive with -UserId.
+
+        .OUTPUTS
+        The API response from the DELETE call (typically the string "Delete success").
+
+        .EXAMPLE
+        PS> Remove-JuribaListTeamUserAccess -ObjectType Device -ListId 1234 -UserId "abc-123-..."
+
+        .EXAMPLE
+        PS> Remove-JuribaListTeamUserAccess -ObjectType Device -ListId 1234 -TeamId "5"
+    #>
+    [CmdletBinding(SupportsShouldProcess, DefaultParameterSetName='User')]
+    [OutputType([String])]
+    param(
+        [Parameter(Mandatory=$false)]
+        [string]$Instance,
+        [Parameter(Mandatory=$false)]
+        [string]$APIKey,
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice")]
+        [string]$ObjectType,
+        [Parameter(Mandatory=$true)]
+        [int]$ListId,
+        [Parameter(Mandatory=$true, ParameterSetName='User')]
+        [string]$UserId,
+        [Parameter(Mandatory=$true, ParameterSetName='Team')]
+        [string]$TeamId
+    )
+
+    if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
+        $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
+        $Instance = $dwConnection.instance
+    }
+
+    if ($APIKey -and $Instance) {
+        $endpoint = ""
+        switch ($ObjectType) {
+            "ApplicationUser"   { throw "not implemented" }
+            "ApplicationDevice" { throw "not implemented" }
+            "Device"            { $endpoint = "devices" }
+            "User"              { $endpoint = "users " }
+            "Application"       { $endpoint = "applications" }
+            "Mailbox"           { $endpoint = "mailboxes" }
+        }
+
+        if ($PSCmdlet.ParameterSetName -eq 'User') {
+            $target = "user"
+            $targetId = $UserId
+        } else {
+            $target = "team"
+            $targetId = $TeamId
+        }
+
+        $headers = @{ 'X-API-KEY' = $APIKey }
+        $uri = "{0}/apiv1/lists/{1}/{2}/{3}/{4}" -f $Instance, $endpoint, $ListId, $target, $targetId
+
+        try {
+            if ($PSCmdlet.ShouldProcess($targetId)) {
+                $result = Invoke-RestMethod -Uri $uri -Method DELETE -Headers $headers
+                return $result
+            }
+        }
+        catch {
+            Write-Error $_
+        }
+    } else {
+        Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
+    }
+}

--- a/Juriba.DPC/Public/Remove-JuribaTeam.ps1
+++ b/Juriba.DPC/Public/Remove-JuribaTeam.ps1
@@ -35,6 +35,7 @@ function Remove-JuribaTeam {
         $Instance = $dwConnection.instance
     }
 
+    $contentType = 'application/json'
     $headers = @{ 'X-API-KEY' = $ApiKey }
     $uri = "{0}/apiv1/admin/team/deleteTeams" -f $Instance
 

--- a/Juriba.DPC/Public/Set-JuribaListAccessType.ps1
+++ b/Juriba.DPC/Public/Set-JuribaListAccessType.ps1
@@ -121,18 +121,22 @@ function Set-JuribaListAccessType {
             throw "Administer access ($newAdmin) cannot be more permissive than Edit access ($newEdit). The DPC API requires View >= Edit >= Administer."
         }
 
-        $body = @{
-            listId                     = $current.listId
-            listName                   = $current.listName
-            listDescription            = $current.listDescription
-            listType                   = $current.listType
-            queryString                = $current.queryString
-            sharedReadAccessType       = $newView
-            sharedEditAccessType       = $newEdit
-            sharedAdministerAccessType = $newAdmin
-            userId                     = $current.userId
-            cachedKeySetId             = $current.cachedKeySetId
-        } | ConvertTo-Json
+        # Build the PUT body from the fields the GET actually returned. Older DPC
+        # versions may omit fields like listDescription, and direct property access
+        # under Set-StrictMode would error on those. Copying conditionally also
+        # avoids pinning the function to one DPC schema version.
+        $putBody = [ordered]@{}
+        foreach ($field in @('listId', 'listName', 'listDescription', 'listType',
+                             'queryString', 'userId', 'cachedKeySetId')) {
+            if ($current.PSObject.Properties.Name -contains $field) {
+                $putBody[$field] = $current.$field
+            }
+        }
+        $putBody['sharedReadAccessType']       = $newView
+        $putBody['sharedEditAccessType']       = $newEdit
+        $putBody['sharedAdministerAccessType'] = $newAdmin
+
+        $body = $putBody | ConvertTo-Json
 
         try {
             if ($PSCmdlet.ShouldProcess("List $ListId")) {

--- a/Juriba.DPC/Public/Set-JuribaListAccessType.ps1
+++ b/Juriba.DPC/Public/Set-JuribaListAccessType.ps1
@@ -1,0 +1,150 @@
+#requires -Version 7
+function Set-JuribaListAccessType {
+    <#
+        .SYNOPSIS
+        Updates the View, Edit and Administer access type of an existing list.
+
+        .DESCRIPTION
+        Uses ApiV1 to update the sharedReadAccessType, sharedEditAccessType and
+        sharedAdministerAccessType fields of an existing list. The endpoint requires
+        the full list payload, so this function fetches the current state, applies
+        only the access types supplied by the caller, and PUTs the result back.
+
+        The DPC API enforces a permissiveness hierarchy: View must be at least as
+        permissive as Edit, and Edit at least as permissive as Administer
+        (Owner < SpecificUserTeam < Everyone). Violating this returns a generic
+        validation error from the server, so this function validates client-side
+        and throws a descriptive error before sending.
+
+        Setting an access type to "SpecificUserTeam" creates a list configured to
+        accept specific user/team grants but does not assign any. Use
+        Set-JuribaListTeamUserAccess to grant access to a user or team after
+        changing the access type.
+
+        .PARAMETER Instance
+        Optional. Juriba instance to be provided if not authenticating using Connect-Juriba. For example, https://myinstance.dpc.juriba.app
+
+        .PARAMETER APIKey
+        Optional. API key to be provided if not authenticating using Connect-Juriba.
+
+        .PARAMETER ObjectType
+        Base object type for the list. Accepts one of: "Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice"
+
+        .PARAMETER ListId
+        The id of the list to update.
+
+        .PARAMETER ViewAccessType
+        Optional. Sets the View access permission. Accepts one of: "Owner", "Everyone", "SpecificUserTeam".
+
+        .PARAMETER EditAccessType
+        Optional. Sets the Edit access permission. Accepts one of: "Owner", "Everyone", "SpecificUserTeam".
+
+        .PARAMETER AdminAccessType
+        Optional. Sets the Administer access permission. Accepts one of: "Owner", "Everyone", "SpecificUserTeam".
+
+        .OUTPUTS
+        The API response from the PUT call (typically the string "Update success").
+
+        .EXAMPLE
+        PS> Set-JuribaListAccessType -Instance "https://myinstance.dpc.juriba.app" -APIKey "xxx" `
+                -ObjectType Device -ListId 1234 -ViewAccessType SpecificUserTeam
+
+        .EXAMPLE
+        PS> Set-JuribaListAccessType -ObjectType Device -ListId 1234 `
+                -ViewAccessType SpecificUserTeam -EditAccessType SpecificUserTeam
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([String])]
+    param(
+        [Parameter(Mandatory=$false)]
+        [string]$Instance,
+        [Parameter(Mandatory=$false)]
+        [string]$APIKey,
+        [Parameter(Mandatory=$true)]
+        [ValidateSet("Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice")]
+        [string]$ObjectType,
+        [Parameter(Mandatory=$true)]
+        [int]$ListId,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Owner", "Everyone", "SpecificUserTeam")]
+        [string]$ViewAccessType,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Owner", "Everyone", "SpecificUserTeam")]
+        [string]$EditAccessType,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Owner", "Everyone", "SpecificUserTeam")]
+        [string]$AdminAccessType
+    )
+
+    if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
+        $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
+        $Instance = $dwConnection.instance
+    }
+
+    if ($APIKey -and $Instance) {
+        if (-not ($ViewAccessType -or $EditAccessType -or $AdminAccessType)) {
+            throw "At least one of -ViewAccessType, -EditAccessType or -AdminAccessType must be specified."
+        }
+
+        $endpoint = ""
+        switch ($ObjectType) {
+            "ApplicationUser"   { throw "not implemented" }
+            "ApplicationDevice" { throw "not implemented" }
+            "Device"            { $endpoint = "devices" }
+            "User"              { $endpoint = "users " }
+            "Application"       { $endpoint = "applications" }
+            "Mailbox"           { $endpoint = "mailboxes" }
+        }
+
+        $headers = @{ 'X-API-KEY' = $APIKey }
+        $uri = "{0}/apiv1/lists/{1}/{2}" -f $Instance, $endpoint, $ListId
+
+        try {
+            $current = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+        }
+        catch {
+            Write-Error ("Failed to fetch list {0}: {1}" -f $ListId, $_)
+            return
+        }
+
+        $newView  = if ($ViewAccessType)  { $ViewAccessType }  else { $current.sharedReadAccessType }
+        $newEdit  = if ($EditAccessType)  { $EditAccessType }  else { $current.sharedEditAccessType }
+        $newAdmin = if ($AdminAccessType) { $AdminAccessType } else { $current.sharedAdministerAccessType }
+
+        # Owner < SpecificUserTeam < Everyone in permissiveness; the API rejects
+        # configurations where Edit is more permissive than View, or Admin than Edit.
+        $rank = @{ 'Owner' = 1; 'SpecificUserTeam' = 5; 'Everyone' = 6 }
+        if ($rank[$newEdit] -gt $rank[$newView]) {
+            throw "Edit access ($newEdit) cannot be more permissive than View access ($newView). The DPC API requires View >= Edit >= Administer."
+        }
+        if ($rank[$newAdmin] -gt $rank[$newEdit]) {
+            throw "Administer access ($newAdmin) cannot be more permissive than Edit access ($newEdit). The DPC API requires View >= Edit >= Administer."
+        }
+
+        $body = @{
+            listId                     = $current.listId
+            listName                   = $current.listName
+            listDescription            = $current.listDescription
+            listType                   = $current.listType
+            queryString                = $current.queryString
+            sharedReadAccessType       = $newView
+            sharedEditAccessType       = $newEdit
+            sharedAdministerAccessType = $newAdmin
+            userId                     = $current.userId
+            cachedKeySetId             = $current.cachedKeySetId
+        } | ConvertTo-Json
+
+        try {
+            if ($PSCmdlet.ShouldProcess("List $ListId")) {
+                $result = Invoke-RestMethod -Uri $uri -Method PUT -Headers $headers `
+                    -ContentType "application/json" -Body $body
+                return $result
+            }
+        }
+        catch {
+            Write-Error $_
+        }
+    } else {
+        Write-Error "No connection found. Please ensure `$APIKey and `$Instance is provided or connect using Connect-Juriba before proceeding."
+    }
+}

--- a/Juriba.DPC/Public/Set-JuribaListTeamUserAccess.ps1
+++ b/Juriba.DPC/Public/Set-JuribaListTeamUserAccess.ps1
@@ -16,17 +16,17 @@ Function Set-JuribaListTeamUserAccess {
 
         .PARAMETER ObjectType
 
-        Base object type for the new list. Accepts one of: "Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplciationDevice"
+        Base object type for the new list. Accepts one of: "Device", "User", "Application", "Mailbox", "ApplicationUser", "ApplicationDevice"
 
         .PARAMETER AccessType
 
-        Sets the Team Access permissions for the list. Accepts one of: "Edit", "Admin". Optional, if ommited "Edit" is used.
-  
+        Sets the Team Access permissions for the list. Accepts one of: "Read", "Edit", "Admin". Optional, if ommited "Edit" is used.
+
         .PARAMETER UserTeam
-		
-		Sets the type of User / Team to be set up. Accepts one of: "Team", "User".
-		
-		.PARAMETER ListID
+
+        Sets the type of User / Team to be set up. Accepts one of: "Team", "User".
+
+        .PARAMETER ListID
 
         Used in the Header to find the Lsit to update Team permissions.
 
@@ -36,15 +36,15 @@ Function Set-JuribaListTeamUserAccess {
 
         .EXAMPLE
 
-        PS> Set-JuribaListTeamUserAccess 
+        PS> Set-JuribaListTeamUserAccess
             -Instance "https://myinstance.juriba.app:8443"
             -APIKey "xxxxx"
             -ObjectType "Device"
             -AccessType "Admin"
-			-UserTeam "User"
+            -UserTeam "User"
             -ListID 1234
             -TeamID 3
-			-UserId "xxxxxxxxx"
+            -UserId "xxxxxxxxx"
 
     #>
     [CmdletBinding(SupportsShouldProcess)]
@@ -53,19 +53,19 @@ Function Set-JuribaListTeamUserAccess {
         [string]$Instance,
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
-		[Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [string]$ObjectType,
-        [Parameter(Mandatory = $false)] 
-        [ValidateSet("Admin", "Edit")]
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("Read", "Admin", "Edit")]
         [string]$AccessType = "Edit",
-		[Parameter(Mandatory = $true)]
-		[ValidateSet("Team", "User")]
-		[string]$UserTeam,
-		[Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Team", "User")]
+        [string]$UserTeam,
+        [Parameter(Mandatory = $true)]
         [string]$ListID,
         [Parameter(Mandatory = $false)]
         [string]$Teamid,
-		[Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false)]
         [string]$Userid
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -75,7 +75,7 @@ Function Set-JuribaListTeamUserAccess {
 
     if ($APIKey -and $Instance) {
         $endpoint = ""
-		switch ($ObjectType) {
+        switch ($ObjectType) {
             "ApplicationUser" { throw "not implemented" }
             "ApplicationDevice" { throw "not implemented" }
             "Device" { $endpoint = "devices"}
@@ -83,11 +83,11 @@ Function Set-JuribaListTeamUserAccess {
             "Application" { $endpoint = "applications" }
             "Mailbox" { $endpoint = "mailboxes" }
         }
-		
+
         $body = @{
-            "userid"						= $Userid
-			"teamID"                        = $TeamId
-            "accessType"				    = $AccessType
+            "userid"     = $Userid
+            "teamID"     = $TeamId
+            "accessType" = $AccessType
         } | ConvertTo-Json
 
         $contentType = "application/json"

--- a/Juriba.DPC/Public/Set-JuribaListTeamUserAccess.ps1
+++ b/Juriba.DPC/Public/Set-JuribaListTeamUserAccess.ps1
@@ -20,7 +20,7 @@ Function Set-JuribaListTeamUserAccess {
 
         .PARAMETER AccessType
 
-        Sets the Team Access permissions for the list. Accepts one of: "Read", "Edit", "Admin". Optional, if ommited "Edit" is used.
+        Sets the Team Access permissions for the list. Accepts one of: "ReadOnly", "Edit", "Admin". Optional, if ommited "Edit" is used.
 
         .PARAMETER UserTeam
 
@@ -56,7 +56,7 @@ Function Set-JuribaListTeamUserAccess {
         [Parameter(Mandatory = $true)]
         [string]$ObjectType,
         [Parameter(Mandatory = $false)]
-        [ValidateSet("Read", "Admin", "Edit")]
+        [ValidateSet("ReadOnly", "Admin", "Edit")]
         [string]$AccessType = "Edit",
         [Parameter(Mandatory = $true)]
         [ValidateSet("Team", "User")]


### PR DESCRIPTION
## Summary

Adds end-to-end programmatic management of list permissions, matching the UI's create-then-share flow. Also absorbs the `Remove-JuribaTeam` content-type fix from #145 so that PR can be closed without a partial revert.

- **`Set-JuribaListAccessType`** (new) — change View / Edit / Administer access type on an existing list. GET-then-PUT (the API requires the full list payload), with client-side validation of the View ≥ Edit ≥ Administer hierarchy so callers get a descriptive error instead of the API's generic `"Request Validation Failed"`. Conditionally copies fields from the GET response so the function tolerates schema differences between DPC versions.
- **`Remove-JuribaListTeamUserAccess`** (new) — revoke a previously-granted user or team via `DELETE /apiv1/lists/{type}/{listId}/{user|team}/{id}`. Mutually-exclusive `-UserId` / `-TeamId` parameter sets.
- **`Set-JuribaListTeamUserAccess`** widened to accept `ReadOnly` as an `AccessType`, completing the set so all three access levels are reachable when `sharedXxxAccessType` is `SpecificUserTeam`. Tab indentation also normalised to 4 spaces. (`ReadOnly` is the literal string the API expects; `"Read"` is silently dropped server-side.)
- **`Remove-JuribaTeam`** — adds the missing \`\$contentType = 'application/json'\` assignment that the existing `Invoke-WebRequest -ContentType \$contentType` call relied on. Originally Paul's fix from #145.
- **Typo cleanup** — fixes `ApplciationDevice` → `ApplicationDevice` across five files (notably, `New-JuribaList` and `Remove-JuribaList` had the typo only in their `ValidateSet`, while their `switch` statements used the correct spelling, so callers couldn't satisfy validation and reach the implementation), and `Eveyone` → `Everyone` in three help blocks of `New-JuribaList`.

## Background

Surfaced from #145, which tried to add `SpecificUserTeam` to `New-JuribaList`'s `Shared*AccessType` parameters. Empirical testing showed:

1. The DPC API enforces a hierarchy: View ≥ Edit ≥ Administer in permissiveness (`Owner < SpecificUserTeam < Everyone`).
2. Setting `SpecificUserTeam` at create time produces a list with `listUserAccess: []` — the secondary grant call (`Set-JuribaListTeamUserAccess`) is a silent no-op against an `Owner`-only list, so callers couldn't actually share the list without a follow-up access-type change anyway.
3. The UI never sets access types at create; it always uses defaults and changes them post-creation via `PUT /apiv1/lists/{type}/{listId}` with the full list body.

So `New-JuribaList` was the wrong place for this. The follow-up modelled here mirrors the UI: create with defaults → change access type → grant users/teams. With #145 now folded in here, that PR can be closed.

## Files changed

| File | Change |
|---|---|
| `Juriba.DPC/Public/Set-JuribaListAccessType.ps1` | New |
| `Juriba.DPC/Public/Remove-JuribaListTeamUserAccess.ps1` | New |
| `Juriba.DPC/Public/Set-JuribaListTeamUserAccess.ps1` | `AccessType` ValidateSet widened to include `ReadOnly`; tabs → 4 spaces; typo fix |
| `Juriba.DPC/Public/Remove-JuribaTeam.ps1` | Adds the missing `\$contentType = 'application/json'` line (from #145) |
| `Juriba.DPC/Public/New-JuribaList.ps1` | Typo fixes only (`Eveyone`, `ApplciationDevice`) |
| `Juriba.DPC/Public/Remove-JuribaList.ps1` | `ApplciationDevice` typo fix in ValidateSet |
| `Juriba.DPC/Juriba.DPC.psd1` | Version bump 1.1.16.0 → 1.1.17.0; two new exports |

## Test plan

- [x] `test-list-access-functions.ps1` (kept local, untracked) — all 9 scenarios passing end-to-end against a real DPC instance:
  - argument validation (\`At least one of -ViewAccessType...\`)
  - hierarchy validation (Edit > View, Admin > Edit)
  - single-field update preserves all other list fields
  - all-three update in one call
  - end-to-end grant Edit → verify in `listUserAccess` → revoke → verify empty
  - `ReadOnly` accessType grants user read access (accessTypeId 1)
  - revert from `SpecificUserTeam` to `Owner` in one call
  - `Remove-JuribaListTeamUserAccess` parameter-set exclusivity
- [x] PSScriptAnalyzer clean — \`Invoke-ScriptAnalyzer -Path .\Juriba.DPC -Recurse -EnableExit -ExcludeRule PSAvoidTrailingWhitespace\`
- [x] CI checks pass
- [x] Paul re-tested `Set-JuribaListAccessType` against an older DPC version (schema-tolerance fix confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)