### PR TITLE
Parallel Paging enhacements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,4 @@
 /Examples/    @juribalimited/product
 /Juriba.DPC/    @juribalimited/product
 /Juriba.DPC.ServiceNow/ @juribalimited/product
+/Tests/    @juribalimited/product

--- a/Juriba.DPC/Juriba.DPC.psd1
+++ b/Juriba.DPC/Juriba.DPC.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'Juriba.DPC.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.1.17.0'
+    ModuleVersion     = '1.1.18.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/Juriba.DPC/Private/Invoke-JuribaPagedRequest.ps1
+++ b/Juriba.DPC/Private/Invoke-JuribaPagedRequest.ps1
@@ -8,9 +8,15 @@ function Invoke-JuribaPagedRequest {
         .DESCRIPTION
         Fetches the first page, reads totalPages from the X-Pagination header and
         then pulls pages 2..N. On PowerShell 7+ the remaining pages are pulled in
-        parallel (throttled by ThrottleLimit); on Windows PowerShell 5.1 it falls
-        back to sequential paging. Transient failures (HTTP 429 and 5xx) are
-        retried with a short backoff.
+        parallel (throttled by ThrottleLimit). If any parallel request fails the
+        helper falls back to the sequential path for pages 2..N; this ensures the
+        caller receives a faithful terminating error (HTTP details are lost when an
+        exception crosses the parallel runspace boundary) and that transient
+        failures are retried rather than silently returning partial data. On
+        Windows PowerShell 5.1, or when ThrottleLimit is 1, paging is sequential.
+
+        Transient failures (HTTP 429, 5xx and transport errors) are retried by
+        Invoke-JuribaWebRequestWithRetry on the sequential path.
 
         Returns the combined array of parsed JSON objects across all pages. The
         caller is responsible for any InfoLevel / property selection. Errors are
@@ -77,45 +83,43 @@ function Invoke-JuribaPagedRequest {
     $remainingPages = 2..$totalPages
 
     if ($PSVersionTable.PSVersion.Major -ge 7 -and $ThrottleLimit -gt 1) {
-        # PowerShell 7+: pull the remaining pages in parallel. Parallel runspaces
-        # cannot see module-private functions, so the retry logic is inlined here
-        # to mirror Invoke-JuribaWebRequestWithRetry.
+        # Fast path: pull the remaining pages in parallel. Each iteration reports
+        # success or failure via a flag - -ErrorAction / -ErrorVariable are not
+        # supported in the -Parallel parameter set. Retry is intentionally omitted
+        # here: any failure drops through to the sequential fallback below, which
+        # retries and surfaces a faithful error.
         $pages = $remainingPages | ForEach-Object -ThrottleLimit $ThrottleLimit -Parallel {
             $pagedUri = "{0}{1}page={2}" -f $using:Uri, $using:separator, $_
-            $attempt = 0
-            $maxAttempts = 4
-            while ($true) {
-                try {
-                    $response = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $using:Headers -ContentType $using:ContentType
-                    break
-                }
-                catch {
-                    $status = $null
-                    $responseProperty = $_.Exception.psobject.Properties['Response']
-                    if ($responseProperty -and $responseProperty.Value) {
-                        $status = [int]$responseProperty.Value.StatusCode
-                    }
-                    $attempt++
-                    $retryable = ($status -eq 429) -or ($null -ne $status -and $status -ge 500)
-                    if ($attempt -ge $maxAttempts -or -not $retryable) { throw }
-                    Start-Sleep -Milliseconds ([int](200 * [math]::Pow(2, $attempt)))
-                }
+            try {
+                $response = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $using:Headers -ContentType $using:ContentType
+                # Emit page number alongside content so results can be re-ordered.
+                [pscustomobject]@{ Page = $_; Content = $response.Content; Failed = $false }
             }
-            # Emit page number alongside content so results can be re-ordered.
-            [pscustomobject]@{ Page = $_; Content = $response.Content }
+            catch {
+                [pscustomobject]@{ Page = $_; Content = $null; Failed = $true }
+            }
         }
-        # Parallel results arrive out of order; re-sort to keep output deterministic.
-        foreach ($page in ($pages | Sort-Object Page)) {
-            & $addContent $page.Content
+
+        if (-not ($pages | Where-Object { $_.Failed })) {
+            # Parallel results arrive out of order; re-sort for deterministic output.
+            foreach ($page in ($pages | Sort-Object Page)) {
+                & $addContent $page.Content
+            }
+            return $items.ToArray()
         }
+
+        # A parallel request failed. Discard the partial parallel output (only
+        # page 1 has been added to $items) and rebuild pages 2..N sequentially so
+        # the caller gets a faithful, retryable result.
+        Write-Verbose "Parallel paging failed; retrying pages 2..$totalPages sequentially."
     }
-    else {
-        # Windows PowerShell 5.1 (or ThrottleLimit = 1): sequential paging.
-        foreach ($page in $remainingPages) {
-            $pagedUri = "{0}{1}page={2}" -f $Uri, $separator, $page
-            $pagedResult = Invoke-JuribaWebRequestWithRetry -Uri $pagedUri -Headers $Headers -ContentType $ContentType
-            & $addContent $pagedResult.Content
-        }
+
+    # Sequential paging: Windows PowerShell 5.1, ThrottleLimit = 1, or the
+    # fallback after a parallel failure.
+    foreach ($page in $remainingPages) {
+        $pagedUri = "{0}{1}page={2}" -f $Uri, $separator, $page
+        $pagedResult = Invoke-JuribaWebRequestWithRetry -Uri $pagedUri -Headers $Headers -ContentType $ContentType
+        & $addContent $pagedResult.Content
     }
 
     return $items.ToArray()

--- a/Juriba.DPC/Private/Invoke-JuribaPagedRequest.ps1
+++ b/Juriba.DPC/Private/Invoke-JuribaPagedRequest.ps1
@@ -8,15 +8,17 @@ function Invoke-JuribaPagedRequest {
         .DESCRIPTION
         Fetches the first page, reads totalPages from the X-Pagination header and
         then pulls pages 2..N. On PowerShell 7+ the remaining pages are pulled in
-        parallel (throttled by ThrottleLimit). If any parallel request fails the
-        helper falls back to the sequential path for pages 2..N; this ensures the
+        parallel (throttled by ThrottleLimit). Each parallel page retries transient
+        failures in place (see below), so a rate-limit response - including one
+        provoked by the concurrent burst - is absorbed rather than aborting the
+        batch. If a page still fails after retries (a non-transient error such as
+        404/401) the helper falls back to the sequential path for pages 2..N so the
         caller receives a faithful terminating error (HTTP details are lost when an
-        exception crosses the parallel runspace boundary) and that transient
-        failures are retried rather than silently returning partial data. On
-        Windows PowerShell 5.1, or when ThrottleLimit is 1, paging is sequential.
+        exception crosses the parallel runspace boundary). On Windows PowerShell
+        5.1, or when ThrottleLimit is 1, paging is sequential.
 
         Transient failures (HTTP 429, 5xx and transport errors) are retried by
-        Invoke-JuribaWebRequestWithRetry on the sequential path.
+        Invoke-JuribaWebRequestWithRetry on both the parallel and sequential paths.
 
         Returns the combined array of parsed JSON objects across all pages. The
         caller is responsible for any InfoLevel / property selection. Errors are
@@ -85,13 +87,21 @@ function Invoke-JuribaPagedRequest {
     if ($PSVersionTable.PSVersion.Major -ge 7 -and $ThrottleLimit -gt 1) {
         # Fast path: pull the remaining pages in parallel. Each iteration reports
         # success or failure via a flag - -ErrorAction / -ErrorVariable are not
-        # supported in the -Parallel parameter set. Retry is intentionally omitted
-        # here: any failure drops through to the sequential fallback below, which
-        # retries and surfaces a faithful error.
+        # supported in the -Parallel parameter set.
+        #
+        # The retry helper is recreated inside each runspace (functions defined in
+        # the module scope are not visible to -Parallel) so every parallel page
+        # gets the same 429/5xx backoff and Retry-After handling as the sequential
+        # path. This lets transient failures - including a 429 provoked by the
+        # concurrent burst itself - self-heal in place rather than discarding all
+        # parallel work and forcing a full sequential re-fetch. Only a persistent,
+        # non-transient failure (e.g. 404/401) drops through to the fallback below.
+        $retryFuncDef = ${function:Invoke-JuribaWebRequestWithRetry}.ToString()
         $pages = $remainingPages | ForEach-Object -ThrottleLimit $ThrottleLimit -Parallel {
+            ${function:Invoke-JuribaWebRequestWithRetry} = $using:retryFuncDef
             $pagedUri = "{0}{1}page={2}" -f $using:Uri, $using:separator, $_
             try {
-                $response = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $using:Headers -ContentType $using:ContentType
+                $response = Invoke-JuribaWebRequestWithRetry -Uri $pagedUri -Headers $using:Headers -ContentType $using:ContentType
                 # Emit page number alongside content so results can be re-ordered.
                 [pscustomobject]@{ Page = $_; Content = $response.Content; Failed = $false }
             }
@@ -108,9 +118,11 @@ function Invoke-JuribaPagedRequest {
             return $items.ToArray()
         }
 
-        # A parallel request failed. Discard the partial parallel output (only
-        # page 1 has been added to $items) and rebuild pages 2..N sequentially so
-        # the caller gets a faithful, retryable result.
+        # A page failed even after in-runspace retries (i.e. a non-transient
+        # error, or one that exhausted its retries). Discard the partial parallel
+        # output (only page 1 has been added to $items) and rebuild pages 2..N
+        # sequentially so the caller gets a faithful terminating error - HTTP
+        # details are lost when an exception crosses the parallel runspace boundary.
         Write-Verbose "Parallel paging failed; retrying pages 2..$totalPages sequentially."
     }
 

--- a/Juriba.DPC/Private/Invoke-JuribaPagedRequest.ps1
+++ b/Juriba.DPC/Private/Invoke-JuribaPagedRequest.ps1
@@ -1,0 +1,122 @@
+function Invoke-JuribaPagedRequest {
+    <#
+        .SYNOPSIS
+        Internal helper. Performs a GET request and, when the response is paged
+        (indicated by the X-Pagination response header), retrieves all remaining
+        pages and returns the combined, parsed result set.
+
+        .DESCRIPTION
+        Fetches the first page, reads totalPages from the X-Pagination header and
+        then pulls pages 2..N. On PowerShell 7+ the remaining pages are pulled in
+        parallel (throttled by ThrottleLimit); on Windows PowerShell 5.1 it falls
+        back to sequential paging. Transient failures (HTTP 429 and 5xx) are
+        retried with a short backoff.
+
+        Returns the combined array of parsed JSON objects across all pages. The
+        caller is responsible for any InfoLevel / property selection. Errors are
+        allowed to propagate so each calling function can apply its own catch
+        semantics (e.g. treating 404 as "not found").
+
+        .PARAMETER Uri
+        The fully-formed request URI for the first page. May or may not already
+        contain a query string; the page parameter is appended with the correct
+        separator (? or &).
+
+        .PARAMETER Headers
+        Request headers, including the x-api-key.
+
+        .PARAMETER ContentType
+        Optional. Defaults to "application/json".
+
+        .PARAMETER ThrottleLimit
+        Optional. Maximum number of pages to request concurrently on PowerShell
+        7+. Defaults to 8. Set to 1 to force sequential paging.
+    #>
+    [CmdletBinding()]
+    [OutputType([Object[]])]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$Uri,
+        [Parameter(Mandatory=$true)]
+        [hashtable]$Headers,
+        [Parameter(Mandatory=$false)]
+        [string]$ContentType = "application/json",
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
+    )
+
+    $items = [System.Collections.Generic.List[object]]::new()
+
+    # Parses a page's raw content and appends any objects to the result list.
+    # '[]' and empty content are treated as "no items" so we never add a $null.
+    $addContent = {
+        param($content)
+        if (-not [string]::IsNullOrWhiteSpace($content) -and $content.Trim() -ne '[]') {
+            foreach ($object in @($content | ConvertFrom-Json)) {
+                $items.Add($object)
+            }
+        }
+    }
+
+    $firstPage = Invoke-JuribaWebRequestWithRetry -Uri $Uri -Headers $Headers -ContentType $ContentType
+    & $addContent $firstPage.Content
+
+    # Not paged - return the single page as-is.
+    if (-not $firstPage.Headers.ContainsKey("X-Pagination")) {
+        return $items.ToArray()
+    }
+
+    $totalPages = ($firstPage.Headers."X-Pagination" | ConvertFrom-Json).totalPages
+    if ($totalPages -le 1) {
+        return $items.ToArray()
+    }
+
+    # The first-page URI may or may not already carry a query string.
+    $separator = if ($Uri.Contains("?")) { "&" } else { "?" }
+    $remainingPages = 2..$totalPages
+
+    if ($PSVersionTable.PSVersion.Major -ge 7 -and $ThrottleLimit -gt 1) {
+        # PowerShell 7+: pull the remaining pages in parallel. Parallel runspaces
+        # cannot see module-private functions, so the retry logic is inlined here
+        # to mirror Invoke-JuribaWebRequestWithRetry.
+        $pages = $remainingPages | ForEach-Object -ThrottleLimit $ThrottleLimit -Parallel {
+            $pagedUri = "{0}{1}page={2}" -f $using:Uri, $using:separator, $_
+            $attempt = 0
+            $maxAttempts = 4
+            while ($true) {
+                try {
+                    $response = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $using:Headers -ContentType $using:ContentType
+                    break
+                }
+                catch {
+                    $status = $null
+                    $responseProperty = $_.Exception.psobject.Properties['Response']
+                    if ($responseProperty -and $responseProperty.Value) {
+                        $status = [int]$responseProperty.Value.StatusCode
+                    }
+                    $attempt++
+                    $retryable = ($status -eq 429) -or ($null -ne $status -and $status -ge 500)
+                    if ($attempt -ge $maxAttempts -or -not $retryable) { throw }
+                    Start-Sleep -Milliseconds ([int](200 * [math]::Pow(2, $attempt)))
+                }
+            }
+            # Emit page number alongside content so results can be re-ordered.
+            [pscustomobject]@{ Page = $_; Content = $response.Content }
+        }
+        # Parallel results arrive out of order; re-sort to keep output deterministic.
+        foreach ($page in ($pages | Sort-Object Page)) {
+            & $addContent $page.Content
+        }
+    }
+    else {
+        # Windows PowerShell 5.1 (or ThrottleLimit = 1): sequential paging.
+        foreach ($page in $remainingPages) {
+            $pagedUri = "{0}{1}page={2}" -f $Uri, $separator, $page
+            $pagedResult = Invoke-JuribaWebRequestWithRetry -Uri $pagedUri -Headers $Headers -ContentType $ContentType
+            & $addContent $pagedResult.Content
+        }
+    }
+
+    return $items.ToArray()
+}

--- a/Juriba.DPC/Private/Invoke-JuribaWebRequestWithRetry.ps1
+++ b/Juriba.DPC/Private/Invoke-JuribaWebRequestWithRetry.ps1
@@ -1,0 +1,61 @@
+function Invoke-JuribaWebRequestWithRetry {
+    <#
+        .SYNOPSIS
+        Internal helper. Performs a GET via Invoke-WebRequest with a short
+        exponential backoff retry for transient failures.
+
+        .DESCRIPTION
+        Retries only on transient responses (HTTP 429 and 5xx). All other
+        failures (e.g. 404) are re-thrown immediately so that calling functions
+        can apply their own catch semantics. Returns the raw response object from
+        Invoke-WebRequest.
+
+        .PARAMETER Uri
+        The request URI.
+
+        .PARAMETER Headers
+        Request headers, including the x-api-key.
+
+        .PARAMETER ContentType
+        Optional. Defaults to "application/json".
+
+        .PARAMETER MaxAttempts
+        Optional. Total number of attempts before giving up. Defaults to 4.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]$Uri,
+        [Parameter(Mandatory=$true)]
+        [hashtable]$Headers,
+        [Parameter(Mandatory=$false)]
+        [string]$ContentType = "application/json",
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 10)]
+        [int]$MaxAttempts = 4
+    )
+
+    $attempt = 0
+    while ($true) {
+        try {
+            return Invoke-WebRequest -Uri $Uri -Method GET -Headers $Headers -ContentType $ContentType
+        }
+        catch {
+            # Determine the HTTP status code without tripping StrictMode on
+            # exceptions that have no Response property (e.g. DNS failures).
+            $status = $null
+            $responseProperty = $_.Exception.psobject.Properties['Response']
+            if ($responseProperty -and $responseProperty.Value) {
+                $status = [int]$responseProperty.Value.StatusCode
+            }
+
+            $attempt++
+            $retryable = ($status -eq 429) -or ($null -ne $status -and $status -ge 500)
+            if ($attempt -ge $MaxAttempts -or -not $retryable) {
+                throw
+            }
+            # Exponential backoff: 400ms, 800ms, 1600ms, ...
+            Start-Sleep -Milliseconds ([int](200 * [math]::Pow(2, $attempt)))
+        }
+    }
+}

--- a/Juriba.DPC/Private/Invoke-JuribaWebRequestWithRetry.ps1
+++ b/Juriba.DPC/Private/Invoke-JuribaWebRequestWithRetry.ps1
@@ -5,10 +5,13 @@ function Invoke-JuribaWebRequestWithRetry {
         exponential backoff retry for transient failures.
 
         .DESCRIPTION
-        Retries only on transient responses (HTTP 429 and 5xx). All other
-        failures (e.g. 404) are re-thrown immediately so that calling functions
-        can apply their own catch semantics. Returns the raw response object from
-        Invoke-WebRequest.
+        Retries on transient conditions: rate limiting (HTTP 429), server errors
+        (HTTP 5xx) and transport-level failures that produced no HTTP response
+        (e.g. a dropped connection). All other failures (e.g. 404) are re-thrown
+        immediately so that calling functions can apply their own catch semantics.
+        When a 429 response carries a Retry-After header its delay is honoured,
+        otherwise an exponential backoff is used. Returns the raw response object
+        from Invoke-WebRequest.
 
         .PARAMETER Uri
         The request URI.
@@ -50,12 +53,29 @@ function Invoke-JuribaWebRequestWithRetry {
             }
 
             $attempt++
-            $retryable = ($status -eq 429) -or ($null -ne $status -and $status -ge 500)
+            # Retry rate limiting (429), server errors (5xx) and transport-level
+            # failures (no HTTP response, so $status is $null).
+            $retryable = ($null -eq $status) -or ($status -eq 429) -or ($status -ge 500)
             if ($attempt -ge $MaxAttempts -or -not $retryable) {
                 throw
             }
-            # Exponential backoff: 400ms, 800ms, 1600ms, ...
-            Start-Sleep -Milliseconds ([int](200 * [math]::Pow(2, $attempt)))
+
+            # Exponential backoff: 400ms, 800ms, 1600ms, ... Honour Retry-After
+            # (best effort) when the server supplies it on a 429.
+            $delayMs = [int](200 * [math]::Pow(2, $attempt))
+            if ($status -eq 429 -and $responseProperty -and $responseProperty.Value) {
+                try {
+                    $retryAfter = $responseProperty.Value.Headers.RetryAfter
+                    if ($retryAfter -and $retryAfter.Delta -and $retryAfter.Delta.TotalMilliseconds -gt 0) {
+                        $delayMs = [int]$retryAfter.Delta.TotalMilliseconds
+                    }
+                }
+                catch {
+                    # Header shape differs across PowerShell editions; fall back to backoff.
+                    Write-Verbose "Could not parse Retry-After header; using exponential backoff."
+                }
+            }
+            Start-Sleep -Milliseconds $delayMs
         }
     }
 }

--- a/Juriba.DPC/Public/Get-JuribaApplicationV1.ps1
+++ b/Juriba.DPC/Public/Get-JuribaApplicationV1.ps1
@@ -49,8 +49,7 @@ function Get-JuribaApplicationV1 {
         $headers = @{'x-api-key' = $APIKey}
 
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
-            return (($result.content) | ConvertFrom-Json)
+            return Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
         }
         catch {
             if ($_.Exception.Response.StatusCode.Value__ -eq 404) {

--- a/Juriba.DPC/Public/Get-JuribaApplicationV1.ps1
+++ b/Juriba.DPC/Public/Get-JuribaApplicationV1.ps1
@@ -20,10 +20,6 @@ function Get-JuribaApplicationV1 {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
-        .PARAMETER ThrottleLimit
-
-        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
-
         .EXAMPLE
         PS> Get-JuribaImportApplication -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx" -ImportId 1 -InfoLevel "Full"
 
@@ -34,10 +30,7 @@ function Get-JuribaApplicationV1 {
         [Parameter(Mandatory=$false)]
         [string]$Instance,
         [Parameter(Mandatory=$false)]
-        [string]$APIKey,
-        [Parameter(Mandatory=$false)]
-        [ValidateRange(1, 64)]
-        [int]$ThrottleLimit = 8
+        [string]$APIKey
     )
 
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -56,7 +49,8 @@ function Get-JuribaApplicationV1 {
         $headers = @{'x-api-key' = $APIKey}
 
         try {
-            return Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
+            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            return (($result.content) | ConvertFrom-Json)
         }
         catch {
             if ($_.Exception.Response.StatusCode.Value__ -eq 404) {

--- a/Juriba.DPC/Public/Get-JuribaApplicationV1.ps1
+++ b/Juriba.DPC/Public/Get-JuribaApplicationV1.ps1
@@ -20,6 +20,10 @@ function Get-JuribaApplicationV1 {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .EXAMPLE
         PS> Get-JuribaImportApplication -Instance "https://myinstance.dashworks.app:8443" -APIKey "xxxxx" -ImportId 1 -InfoLevel "Full"
 
@@ -30,7 +34,10 @@ function Get-JuribaApplicationV1 {
         [Parameter(Mandatory=$false)]
         [string]$Instance,
         [Parameter(Mandatory=$false)]
-        [string]$APIKey
+        [string]$APIKey,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
 
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -49,7 +56,7 @@ function Get-JuribaApplicationV1 {
         $headers = @{'x-api-key' = $APIKey}
 
         try {
-            return Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            return Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
         }
         catch {
             if ($_.Exception.Response.StatusCode.Value__ -eq 404) {

--- a/Juriba.DPC/Public/Get-JuribaImportApplication.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportApplication.ps1
@@ -122,26 +122,10 @@ function Get-JuribaImportApplication {
     
         $application = ""
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             $application = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).UniqueIdentifier }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    if ($uri -match '\?') {
-                        $pagedUri = $uri + "&page={0}" -f $page
-                    } else {
-                        $pagedUri = $uri + "?page={0}" -f $page
-                    }
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $application += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).UniqueIdentifier }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.UniqueIdentifier }
+                "Full"  { $items }
             }
         }
         catch {

--- a/Juriba.DPC/Public/Get-JuribaImportApplication.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportApplication.ps1
@@ -19,6 +19,10 @@ function Get-JuribaImportApplication {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER UniqueIdentifier
 
         UniqueIdentifier for the application.
@@ -71,7 +75,10 @@ function Get-JuribaImportApplication {
         [Parameter(Mandatory=$false ,ParameterSetName="fields")]
         [string[]]$Fields,
         [Parameter(Mandatory=$false)]
-        [int]$PageSize = 200
+        [int]$PageSize = 200,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -122,7 +129,7 @@ function Get-JuribaImportApplication {
     
         $application = ""
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $application = switch($InfoLevel) {
                 "Basic" { $items.UniqueIdentifier }
                 "Full"  { $items }

--- a/Juriba.DPC/Public/Get-JuribaImportDepartment.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportDepartment.ps1
@@ -101,22 +101,10 @@ function Get-JuribaImportDepartment {
     
         $department = ""
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             $department = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).Name }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    $pagedUri = $uri + "&page={0}" -f $page
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $department += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).Name }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.Name }
+                "Full"  { $items }
             }
             return $department
         }

--- a/Juriba.DPC/Public/Get-JuribaImportDepartment.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportDepartment.ps1
@@ -19,6 +19,10 @@ function Get-JuribaImportDepartment {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER Name
 
         Name for the department. Cannot be used with Filter.
@@ -63,7 +67,10 @@ function Get-JuribaImportDepartment {
         [int]$ImportId,
         [parameter(Mandatory=$false)]
         [ValidateSet("Basic", "Full")]
-        [string]$InfoLevel = "Basic"
+        [string]$InfoLevel = "Basic",
+        [parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
 
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -101,7 +108,7 @@ function Get-JuribaImportDepartment {
     
         $department = ""
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $department = switch($InfoLevel) {
                 "Basic" { $items.Name }
                 "Full"  { $items }

--- a/Juriba.DPC/Public/Get-JuribaImportDepartment.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportDepartment.ps1
@@ -38,7 +38,7 @@ function Get-JuribaImportDepartment {
         .PARAMETER InfoLevel
 
         Optional. Sets the level of information that this function returns. Accepts Basic or Full.
-        Basic returns only the Name, use when confirming a department exists.
+        Basic returns only the UniqueIdentifier, use when confirming a department exists.
         Full returns the full json object for the department.
         Default is Basic.
 
@@ -110,7 +110,7 @@ function Get-JuribaImportDepartment {
         try {
             $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $department = switch($InfoLevel) {
-                "Basic" { $items.Name }
+                "Basic" { $items.UniqueIdentifier }
                 "Full"  { $items }
             }
             return $department

--- a/Juriba.DPC/Public/Get-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportDevice.ps1
@@ -19,6 +19,10 @@ function Get-JuribaImportDevice {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER UniqueIdentifier
 
         UniqueIdentifier for the device. Cannot be used with Hostname or Filter.
@@ -81,7 +85,10 @@ function Get-JuribaImportDevice {
         [Parameter(Mandatory=$false ,ParameterSetName="fields")]
         [string[]]$Fields,
         [Parameter(Mandatory=$false)]
-        [int]$PageSize = 200
+        [int]$PageSize = 200,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -138,7 +145,7 @@ function Get-JuribaImportDevice {
     
         $device = @()
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             if ($null -eq $items -or $items.Count -eq 0) { return $device }
             $device = switch($InfoLevel) {
                 "Basic" { $items.UniqueIdentifier }

--- a/Juriba.DPC/Public/Get-JuribaImportDevice.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportDevice.ps1
@@ -138,27 +138,11 @@ function Get-JuribaImportDevice {
     
         $device = @()
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
-            if ($result.Content -eq '[]') {return $device}
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            if ($null -eq $items -or $items.Count -eq 0) { return $device }
             $device = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).UniqueIdentifier }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    if ($uri -match '\?') {
-                        $pagedUri = $uri + "&page={0}" -f $page
-                    } else {
-                        $pagedUri = $uri + "?page={0}" -f $page
-                    }
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $device += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).UniqueIdentifier }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.UniqueIdentifier }
+                "Full"  { $items }
             }
             return $device
         }

--- a/Juriba.DPC/Public/Get-JuribaImportGroup.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportGroup.ps1
@@ -19,6 +19,10 @@ function Get-JuribaImportGroup {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER UniqueIdentifier
 
         UniqueIdentifier for the group. Cannot be used with Name or Filter.
@@ -72,7 +76,10 @@ function Get-JuribaImportGroup {
         [int]$ImportId,
         [parameter(Mandatory=$false)]
         [ValidateSet("Basic", "Full")]
-        [string]$InfoLevel = "Basic"
+        [string]$InfoLevel = "Basic",
+        [parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -115,7 +122,7 @@ function Get-JuribaImportGroup {
         
         $group = ""
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $group = switch($InfoLevel) {
                 "Basic" { $items.UniqueIdentifier }
                 "Full"  { $items }

--- a/Juriba.DPC/Public/Get-JuribaImportGroup.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportGroup.ps1
@@ -115,22 +115,10 @@ function Get-JuribaImportGroup {
         
         $group = ""
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             $group = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).UniqueIdentifier }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    $pagedUri = $uri + "&page={0}" -f $page
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $group += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).UniqueIdentifier }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.UniqueIdentifier }
+                "Full"  { $items }
             }
             return $group
         }

--- a/Juriba.DPC/Public/Get-JuribaImportLocation.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportLocation.ps1
@@ -105,22 +105,10 @@ function Get-JuribaImportLocation {
     
         $device = ""
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             $device = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).UniqueIdentifier }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    $pagedUri = $uri + "&page={0}" -f $page
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $device += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).UniqueIdentifier }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.UniqueIdentifier }
+                "Full"  { $items }
             }
             return $device
         }

--- a/Juriba.DPC/Public/Get-JuribaImportLocation.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportLocation.ps1
@@ -20,6 +20,10 @@ function Get-JuribaImportLocation {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER UniqueIdentifier
 
         UniqueIdentifier for the location. Cannot be used with LocationName or Filter.
@@ -64,7 +68,10 @@ function Get-JuribaImportLocation {
         [int]$ImportId,
         [parameter(Mandatory=$false)]
         [ValidateSet("Basic", "Full")]
-        [string]$InfoLevel = "Basic"
+        [string]$InfoLevel = "Basic",
+        [parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
 
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -105,7 +112,7 @@ function Get-JuribaImportLocation {
     
         $device = ""
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $device = switch($InfoLevel) {
                 "Basic" { $items.UniqueIdentifier }
                 "Full"  { $items }

--- a/Juriba.DPC/Public/Get-JuribaImportMailbox.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportMailbox.ps1
@@ -19,6 +19,10 @@ function Get-JuribaImportMailbox {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER UniqueIdentifier
 
         UniqueIdentifier for the mailbox. Cannot be used with Hostname or Filter.
@@ -74,7 +78,10 @@ function Get-JuribaImportMailbox {
         [Parameter(Mandatory=$false ,ParameterSetName="fields")]
         [string[]]$Fields,
         [Parameter(Mandatory=$false)]
-        [int]$PageSize = 200
+        [int]$PageSize = 200,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
 
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -128,7 +135,7 @@ function Get-JuribaImportMailbox {
     
         $mailbox = ""
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $mailbox = switch($InfoLevel) {
                 "Basic" { $items.UniqueIdentifier }
                 "Full"  { $items }

--- a/Juriba.DPC/Public/Get-JuribaImportMailbox.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportMailbox.ps1
@@ -128,26 +128,10 @@ function Get-JuribaImportMailbox {
     
         $mailbox = ""
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             $mailbox = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).UniqueIdentifier }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    if ($uri -match '\?') {
-                        $pagedUri = $uri + "&page={0}" -f $page
-                    } else {
-                        $pagedUri = $uri + "?page={0}" -f $page
-                    }
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $mailbox += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).UniqueIdentifier }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.UniqueIdentifier }
+                "Full"  { $items }
             }
             return $mailbox
         }

--- a/Juriba.DPC/Public/Get-JuribaImportUser.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportUser.ps1
@@ -38,7 +38,7 @@ function Get-JuribaImportUser {
         .PARAMETER InfoLevel
 
         Optional. Sets the level of information that this function returns. Accepts Basic or Full.
-        Basic returns only the Username, use when confirming a user exists.
+        Basic returns only the UniqueIdentifier, use when confirming a user exists.
         Full returns the full json object for the user.
         Default is Basic.
 
@@ -123,26 +123,10 @@ function Get-JuribaImportUser {
     
         $user = ""
         try {
-            $result = Invoke-WebRequest -Uri $uri -Method GET -Headers $headers -ContentType "application/json"
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             $user = switch($InfoLevel) {
-                "Basic" { ($result.Content | ConvertFrom-Json).Username }
-                "Full"  { $result.Content | ConvertFrom-Json }
-            }
-            # check if result is paged, if so get remaining pages and add to result set
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    if ($uri -match '\?') {
-                        $pagedUri = $uri + "&page={0}" -f $page
-                    } else {
-                        $pagedUri = $uri + "?page={0}" -f $page
-                    }
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $user += switch($InfoLevel) {
-                        "Basic" { ($pagedResult.Content | ConvertFrom-Json).Username }
-                        "Full"  { $pagedResult.Content | ConvertFrom-Json }
-                    }
-                }
+                "Basic" { $items.UniqueIdentifier }
+                "Full"  { $items }
             }
             return $user
         }

--- a/Juriba.DPC/Public/Get-JuribaImportUser.ps1
+++ b/Juriba.DPC/Public/Get-JuribaImportUser.ps1
@@ -19,6 +19,10 @@ function Get-JuribaImportUser {
 
         Optional. API key to be provided if not authenticating using Connect-Juriba.
 
+        .PARAMETER ThrottleLimit
+
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
+
         .PARAMETER Username
 
         Useraname for the user. Cannot be used with Filter.
@@ -71,7 +75,10 @@ function Get-JuribaImportUser {
         [Parameter(Mandatory=$false ,ParameterSetName="fields")]
         [string[]]$Fields,
         [Parameter(Mandatory=$false)]
-        [int]$PageSize = 200
+        [int]$PageSize = 200,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
 
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
@@ -123,7 +130,7 @@ function Get-JuribaImportUser {
     
         $user = ""
         try {
-            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $items = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             $user = switch($InfoLevel) {
                 "Basic" { $items.UniqueIdentifier }
                 "Full"  { $items }

--- a/Juriba.DPC/Public/Get-JuribaTask.ps1
+++ b/Juriba.DPC/Public/Get-JuribaTask.ps1
@@ -37,16 +37,7 @@ function Get-JuribaTask {
             'x-api-key' = $ApiKey
         }
         try {
-            $result = Invoke-WebRequest -Uri $uri -Headers $headers -Method GET
-            $tasks = ($result.Content | ConvertFrom-Json)
-            if ($result.Headers.ContainsKey("X-Pagination")) {
-                $totalPages = ($result.Headers."X-Pagination" | ConvertFrom-Json).totalPages
-                for ($page = 2; $page -le $totalPages; $page++) {
-                    $pagedUri = $uri + "?page={0}" -f $page
-                    $pagedResult = Invoke-WebRequest -Uri $pagedUri -Method GET -Headers $headers -ContentType "application/json"
-                    $tasks += ($pagedResult.Content | ConvertFrom-Json)
-                }
-            }
+            $tasks = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
             return $tasks
         }
         catch {

--- a/Juriba.DPC/Public/Get-JuribaTask.ps1
+++ b/Juriba.DPC/Public/Get-JuribaTask.ps1
@@ -9,6 +9,8 @@ function Get-JuribaTask {
         Dashworks instance. For example, https://myinstance.dashworks.app:8443
         .PARAMETER APIKey
         Dashworks API Key.
+        .PARAMETER ThrottleLimit
+        Optional. Maximum number of pages to request concurrently on PowerShell 7+. Defaults to 8. Set to 1 to force sequential paging.
         .PARAMETER ProjectID
         Project ID to get project tasks from
         .OUTPUTS
@@ -23,7 +25,10 @@ function Get-JuribaTask {
         [Parameter(Mandatory=$false)]
         [string]$APIKey,
         [Parameter(Mandatory=$true)]
-        [int]$ProjectID
+        [int]$ProjectID,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(1, 64)]
+        [int]$ThrottleLimit = 8
     )
     if ((Get-Variable 'dwConnection' -Scope 'Global' -ErrorAction 'Ignore') -and !$APIKey -and !$Instance) {
         $APIKey = ConvertFrom-SecureString -SecureString $dwConnection.secureAPIKey -AsPlainText
@@ -37,7 +42,7 @@ function Get-JuribaTask {
             'x-api-key' = $ApiKey
         }
         try {
-            $tasks = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers
+            $tasks = Invoke-JuribaPagedRequest -Uri $uri -Headers $headers -ThrottleLimit $ThrottleLimit
             return $tasks
         }
         catch {

--- a/Tests/Invoke-JuribaPagedRequest.Tests.ps1
+++ b/Tests/Invoke-JuribaPagedRequest.Tests.ps1
@@ -1,0 +1,170 @@
+#requires -Version 7
+# Pester v5 tests for the private paging helpers Invoke-JuribaPagedRequest and
+# Invoke-JuribaWebRequestWithRetry.
+#
+# These are NOT run by the current CI (which only runs PSScriptAnalyzer) and are
+# not part of the published module. Run locally with Pester 5+:
+#   Invoke-Pester .\Tests\Invoke-JuribaPagedRequest.Tests.ps1
+
+BeforeAll {
+    Set-StrictMode -Version Latest
+    $privateDir = Join-Path $PSScriptRoot '..\Juriba.DPC\Private'
+    . (Resolve-Path (Join-Path $privateDir 'Invoke-JuribaWebRequestWithRetry.ps1'))
+    . (Resolve-Path (Join-Path $privateDir 'Invoke-JuribaPagedRequest.ps1'))
+
+    # Spins up a throwaway HttpListener that pages a 3-page result set. The
+    # 'mode' controls how page 2 behaves so we can exercise the error paths.
+    #   ok         - every page succeeds
+    #   notfound2  - page 2 always returns 404 (non-retryable)
+    #   transient2 - page 2 returns 500 twice then succeeds (retryable)
+    function Start-TestListener {
+        param([int]$Port, [string]$Mode = 'ok')
+        $prefix = "http://localhost:$Port/"
+        $listener = [System.Net.HttpListener]::new()
+        $listener.Prefixes.Add($prefix)
+        $listener.Start()
+        $job = Start-ThreadJob -ScriptBlock {
+            param($listener, $mode)
+            $page2hits = 0
+            while ($true) {
+                try { $ctx = $listener.GetContext() } catch { break }
+                $q = $ctx.Request.Url.Query
+                $page = 1; if ($q -match 'page=(\d+)') { $page = [int]$Matches[1] }
+                $fail = $false; $code = 200
+                if ($page -eq 2) {
+                    if ($mode -eq 'notfound2') { $fail = $true; $code = 404 }
+                    elseif ($mode -eq 'transient2') { $page2hits++; if ($page2hits -le 2) { $fail = $true; $code = 500 } }
+                }
+                $ctx.Response.ContentType = 'application/json'
+                if ($fail) {
+                    $ctx.Response.StatusCode = $code
+                    $b = [System.Text.Encoding]::UTF8.GetBytes('error')
+                } else {
+                    if ($page -eq 1) { $ctx.Response.Headers.Add('X-Pagination', '{"totalPages":3}') }
+                    $b = [System.Text.Encoding]::UTF8.GetBytes(('[{{"id":{0}}}]' -f $page))
+                }
+                $ctx.Response.OutputStream.Write($b, 0, $b.Length)
+                $ctx.Response.Close()
+            }
+        } -ArgumentList $listener, $Mode
+        [pscustomobject]@{ Listener = $listener; Job = $job; Base = ($prefix + 'items?limit=50') }
+    }
+
+    function Stop-TestListener {
+        param($Context)
+        $Context.Listener.Stop(); $Context.Listener.Close()
+        $Context.Job | Remove-Job -Force
+    }
+}
+
+Describe 'Invoke-JuribaWebRequestWithRetry' {
+    It 'returns the response for a successful request' {
+        Mock -CommandName Invoke-WebRequest -MockWith { [pscustomobject]@{ Content = '[{"id":1}]' } }
+        $r = Invoke-JuribaWebRequestWithRetry -Uri 'https://x/y' -Headers @{}
+        $r.Content | Should -Be '[{"id":1}]'
+    }
+
+    It 'does NOT retry a non-transient error (404) and rethrows it' {
+        $script:calls = 0
+        Mock -CommandName Invoke-WebRequest -MockWith {
+            $script:calls++
+            $resp = [pscustomobject]@{ StatusCode = [System.Net.HttpStatusCode]::NotFound }
+            $ex = [System.Exception]::new('Not Found')
+            $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp
+            throw $ex
+        }
+        { Invoke-JuribaWebRequestWithRetry -Uri 'https://x/y' -Headers @{} } | Should -Throw
+        $script:calls | Should -Be 1
+    }
+
+    It 'retries a transient error (500) up to MaxAttempts' {
+        $script:calls = 0
+        Mock -CommandName Invoke-WebRequest -MockWith {
+            $script:calls++
+            $resp = [pscustomobject]@{ StatusCode = [System.Net.HttpStatusCode]::InternalServerError }
+            $ex = [System.Exception]::new('Server Error')
+            $ex | Add-Member -NotePropertyName Response -NotePropertyValue $resp
+            throw $ex
+        }
+        { Invoke-JuribaWebRequestWithRetry -Uri 'https://x/y' -Headers @{} -MaxAttempts 3 } | Should -Throw
+        $script:calls | Should -Be 3
+    }
+}
+
+Describe 'Invoke-JuribaPagedRequest (mocked, sequential)' {
+    It 'aggregates all pages when the response is paged' {
+        Mock -CommandName Invoke-JuribaWebRequestWithRetry -MockWith {
+            $page = 1; if ($Uri -match 'page=(\d+)') { $page = [int]$Matches[1] }
+            $headers = @{}
+            if ($page -eq 1) { $headers['X-Pagination'] = '{"totalPages":3}' }
+            [pscustomobject]@{
+                Content = ('[{{"UniqueIdentifier":"p{0}"}}]' -f $page)
+                Headers = $headers
+            }
+        }
+        $r = Invoke-JuribaPagedRequest -Uri 'https://x/items?limit=50' -Headers @{} -ThrottleLimit 1
+        $r.Count | Should -Be 3
+        ($r.UniqueIdentifier | Sort-Object) -join ',' | Should -Be 'p1,p2,p3'
+    }
+
+    It 'returns a single page when there is no X-Pagination header' {
+        Mock -CommandName Invoke-JuribaWebRequestWithRetry -MockWith {
+            [pscustomobject]@{ Content = '[{"UniqueIdentifier":"only"}]'; Headers = @{} }
+        }
+        $r = Invoke-JuribaPagedRequest -Uri 'https://x/items?limit=50' -Headers @{} -ThrottleLimit 1
+        @($r).Count | Should -Be 1
+        $r.UniqueIdentifier | Should -Be 'only'
+    }
+
+    It 'treats an empty result set ([]) as zero items' {
+        Mock -CommandName Invoke-JuribaWebRequestWithRetry -MockWith {
+            [pscustomobject]@{ Content = '[]'; Headers = @{} }
+        }
+        $r = Invoke-JuribaPagedRequest -Uri 'https://x/items?limit=50' -Headers @{} -ThrottleLimit 1
+        @($r).Count | Should -Be 0
+    }
+
+    It 'appends the page parameter with the correct separator' {
+        $script:requested = [System.Collections.Generic.List[string]]::new()
+        Mock -CommandName Invoke-JuribaWebRequestWithRetry -MockWith {
+            $script:requested.Add($Uri)
+            $page = 1; if ($Uri -match 'page=(\d+)') { $page = [int]$Matches[1] }
+            $headers = @{}
+            if ($page -eq 1) { $headers['X-Pagination'] = '{"totalPages":2}' }
+            [pscustomobject]@{ Content = ('[{{"id":{0}}}]' -f $page); Headers = $headers }
+        }
+        # base URI without a query string -> ?page=2
+        Invoke-JuribaPagedRequest -Uri 'https://x/tasks' -Headers @{} -ThrottleLimit 1 | Out-Null
+        $script:requested[1] | Should -Be 'https://x/tasks?page=2'
+    }
+}
+
+Describe 'Invoke-JuribaPagedRequest (parallel, live HttpListener)' {
+    It 'pulls all pages in parallel on the happy path' {
+        $ctx = Start-TestListener -Port 9201 -Mode 'ok'
+        try {
+            $r = Invoke-JuribaPagedRequest -Uri $ctx.Base -Headers @{} -ThrottleLimit 8
+            $r.Count | Should -Be 3
+            ($r.id | Sort-Object) -join ',' | Should -Be '1,2,3'
+        } finally { Stop-TestListener $ctx }
+    }
+
+    It 'falls back to sequential and surfaces a faithful 404 when a page persistently fails' {
+        $ctx = Start-TestListener -Port 9202 -Mode 'notfound2'
+        try {
+            $status = $null
+            try { Invoke-JuribaPagedRequest -Uri $ctx.Base -Headers @{} -ThrottleLimit 8 }
+            catch { $status = $_.Exception.Response.StatusCode.Value__ }
+            $status | Should -Be 404
+        } finally { Stop-TestListener $ctx }
+    }
+
+    It 'recovers a transient failure via the sequential fallback' {
+        $ctx = Start-TestListener -Port 9203 -Mode 'transient2'
+        try {
+            $r = Invoke-JuribaPagedRequest -Uri $ctx.Base -Headers @{} -ThrottleLimit 8
+            $r.Count | Should -Be 3
+            ($r.id | Sort-Object) -join ',' | Should -Be '1,2,3'
+        } finally { Stop-TestListener $ctx }
+    }
+}


### PR DESCRIPTION
Update all paged functions to use parallel in their pull, new helper functions with retries included.

---

## Breaking change

`Get-JuribaImportUser -InfoLevel Basic` now returns each user's `UniqueIdentifier` instead of `Username`, for consistency with the other `Get-JuribaImport*` functions (Device / Application / Mailbox / Group / Location all return `UniqueIdentifier` for Basic). Scripts that relied on Basic returning usernames should switch to `-InfoLevel Full` and select `.Username`, or use the `-Username` parameter to look up a specific user. Note that a user's unique identifier is not necessarily their username.

Likewise, `Get-JuribaImportDepartment -InfoLevel Basic` now returns each department's `UniqueIdentifier` instead of `Name`, for the same consistency reason. Scripts that relied on Basic returning department names should switch to `-InfoLevel Full` and select `.Name`.

> We are allowing contributions for now with limited review whilst we learn what common practices, approach and recommendations we can follow prior to promoting these modules to our customers.

### Manual Tasks Checklist

- [ ] Increment module version number in /Juriba.Platform/Juriba.Platform.psd1
- [ ] Add new functions to 'FunctionsToExport' in /Juriba.Platform/Juriba.Platform.psd1

